### PR TITLE
Feature: 이달의 신작 소설 조회 api 개선

### DIFF
--- a/novelservice/src/main/java/com/iucyh/novelservice/novel/service/NovelQueryService.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/novel/service/NovelQueryService.java
@@ -82,12 +82,11 @@ public class NovelQueryService {
         return null;
     }
 
-    public PagingResponse<NovelResponse> findNewNovels(NovelPagingRequest pagingRequest) {
-//        return executePagingQuery(pagingRequest,
-//                (searchCondition, pagingQuery) ->
-//                        novelQueryRepository.findNewNovels(searchCondition, pagingQuery, null)
-//        );
-        return null;
+    public PagingResponse<NovelResponse> getNewNovels(GetNovelsQuery query, NovelCategory category) {
+        return executePagingQuery(query,
+                (searchCondition, strategy) ->
+                        novelQueryRepository.findNewNovels(searchCondition, strategy, category)
+        );
     }
 
     private PagingResponse<NovelResponse> executePagingQuery(

--- a/novelservice/src/main/java/com/iucyh/novelservice/novel/web/controller/NovelController.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/novel/web/controller/NovelController.java
@@ -53,10 +53,12 @@ public class NovelController {
 
     @GetMapping("/new")
     public SuccessResponse<PagingResponse<NovelResponse>> getNewNovels(
-            @Valid @ModelAttribute NovelPagingRequest request
+            @Valid @ModelAttribute NovelPagingRequest request,
+            @RequestParam(required = false) NovelCategory category
     ) {
-        PagingResponse<NovelResponse> results = novelQueryService.findNewNovels(request);
-        return ApiResponseMapper.success(results);
+        GetNovelsQuery query = NovelRequestMapper.toGetNovelsQuery(request);
+        PagingResponse<NovelResponse> result = novelQueryService.getNewNovels(query, category);
+        return ApiResponseMapper.success(result);
     }
 
     @GetMapping("/category/{category}")

--- a/novelservice/src/main/java/com/iucyh/novelservice/novel/web/dto/mapper/NovelRequestMapper.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/novel/web/dto/mapper/NovelRequestMapper.java
@@ -31,7 +31,7 @@ public class NovelRequestMapper {
 
     public static GetNovelsQuery toGetNovelsQuery(NovelPagingRequest request) {
         return new GetNovelsQuery(
-                NovelSortType.of(request.sort()),
+                request.sort(),
                 request.cursor(),
                 request.size()
         );

--- a/novelservice/src/main/java/com/iucyh/novelservice/novel/web/dto/request/NovelPagingRequest.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/novel/web/dto/request/NovelPagingRequest.java
@@ -2,11 +2,13 @@ package com.iucyh.novelservice.novel.web.dto.request;
 
 import com.iucyh.novelservice.common.validator.enumfield.EnumField;
 import com.iucyh.novelservice.novel.enumtype.NovelSortType;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import org.hibernate.validator.constraints.Range;
 
 public record NovelPagingRequest(
 
+        @NotNull
         @EnumField(enumClass = NovelSortType.class)
         String sort,
 
@@ -17,10 +19,6 @@ public record NovelPagingRequest(
         Integer size
 ) {
     public NovelPagingRequest {
-        if (sort == null) {
-            sort = NovelSortType.POPULAR.getValue();
-        }
-
         if (size == null) {
             size = 50;
         }

--- a/novelservice/src/main/java/com/iucyh/novelservice/novel/web/dto/request/NovelPagingRequest.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/novel/web/dto/request/NovelPagingRequest.java
@@ -1,6 +1,5 @@
 package com.iucyh.novelservice.novel.web.dto.request;
 
-import com.iucyh.novelservice.common.validator.enumfield.EnumField;
 import com.iucyh.novelservice.novel.enumtype.NovelSortType;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -9,8 +8,7 @@ import org.hibernate.validator.constraints.Range;
 public record NovelPagingRequest(
 
         @NotNull
-        @EnumField(enumClass = NovelSortType.class)
-        String sort,
+        NovelSortType sort,
 
         @Size(max = 2048, message = "Cursor length is too long")
         String cursor,


### PR DESCRIPTION
## 🔖 연관된 이슈
- #25 
## 🧾 작업 내용
- 이달의 신작 소설 조회 api 에 category RequestParam 추가
- 서비스 레이어의 이달의 신작 조회 메서드에서 Query 객체, category 인자를 받도록 수정
- NovelPagingRequest의 sort 필드 타입 Enum 으로 변경, 필수값으로 변경
