### PR TITLE
Feature: NovelStatPeriodType JPA Converter 구현

### DIFF
--- a/novelservice/src/main/java/com/iucyh/novelservice/novel/domain/NovelPeriodStat.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/novel/domain/NovelPeriodStat.java
@@ -1,5 +1,6 @@
 package com.iucyh.novelservice.novel.domain;
 
+import com.iucyh.novelservice.novel.domain.converter.NovelStatPeriodTypeConverter;
 import com.iucyh.novelservice.novel.enumtype.NovelStatPeriodType;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -23,7 +24,7 @@ public class NovelPeriodStat {
     private Long id;
 
     @Column(length = 50, nullable = false)
-    @Enumerated(EnumType.STRING)
+    @Convert(converter = NovelStatPeriodTypeConverter.class)
     private NovelStatPeriodType periodType;
 
     @Column(nullable = false, updatable = false)

--- a/novelservice/src/main/java/com/iucyh/novelservice/novel/domain/NovelPeriodStat.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/novel/domain/NovelPeriodStat.java
@@ -1,6 +1,6 @@
 package com.iucyh.novelservice.novel.domain;
 
-import com.iucyh.novelservice.novel.domain.converter.NovelStatPeriodTypeConverter;
+import com.iucyh.novelservice.novel.domain.converter.NovelStatPeriodTypeJpaConverter;
 import com.iucyh.novelservice.novel.enumtype.NovelStatPeriodType;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -24,7 +24,7 @@ public class NovelPeriodStat {
     private Long id;
 
     @Column(length = 50, nullable = false)
-    @Convert(converter = NovelStatPeriodTypeConverter.class)
+    @Convert(converter = NovelStatPeriodTypeJpaConverter.class)
     private NovelStatPeriodType periodType;
 
     @Column(nullable = false, updatable = false)

--- a/novelservice/src/main/java/com/iucyh/novelservice/novel/domain/converter/NovelStatPeriodTypeConverter.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/novel/domain/converter/NovelStatPeriodTypeConverter.java
@@ -9,7 +9,7 @@ public class NovelStatPeriodTypeConverter implements AttributeConverter<NovelSta
 
     @Override
     public String convertToDatabaseColumn(NovelStatPeriodType attribute) {
-        return attribute.getValue();
+        return attribute == null ? null : attribute.getValue();
     }
 
     @Override

--- a/novelservice/src/main/java/com/iucyh/novelservice/novel/domain/converter/NovelStatPeriodTypeConverter.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/novel/domain/converter/NovelStatPeriodTypeConverter.java
@@ -1,0 +1,19 @@
+package com.iucyh.novelservice.novel.domain.converter;
+
+import com.iucyh.novelservice.novel.enumtype.NovelStatPeriodType;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+@Converter
+public class NovelStatPeriodTypeConverter implements AttributeConverter<NovelStatPeriodType, String> {
+
+    @Override
+    public String convertToDatabaseColumn(NovelStatPeriodType attribute) {
+        return attribute.getValue();
+    }
+
+    @Override
+    public NovelStatPeriodType convertToEntityAttribute(String dbData) {
+        return NovelStatPeriodType.of(dbData);
+    }
+}

--- a/novelservice/src/main/java/com/iucyh/novelservice/novel/domain/converter/NovelStatPeriodTypeJpaConverter.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/novel/domain/converter/NovelStatPeriodTypeJpaConverter.java
@@ -5,7 +5,7 @@ import jakarta.persistence.AttributeConverter;
 import jakarta.persistence.Converter;
 
 @Converter
-public class NovelStatPeriodTypeConverter implements AttributeConverter<NovelStatPeriodType, String> {
+public class NovelStatPeriodTypeJpaConverter implements AttributeConverter<NovelStatPeriodType, String> {
 
     @Override
     public String convertToDatabaseColumn(NovelStatPeriodType attribute) {

--- a/novelservice/src/main/java/com/iucyh/novelservice/novel/enumtype/NovelStatPeriodType.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/novel/enumtype/NovelStatPeriodType.java
@@ -1,7 +1,26 @@
 package com.iucyh.novelservice.novel.enumtype;
 
-// TODO: Enum 값의 별칭 -> DB 변환 컨버터 구현
-public enum NovelStatPeriodType {
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.iucyh.novelservice.common.enumtype.valuedenum.ValuedEnum;
+import com.iucyh.novelservice.common.enumtype.valuedenum.ValuedEnumHelper;
 
-    THREE_DAYS
+public enum NovelStatPeriodType implements ValuedEnum {
+
+    ONE_MONTH("1m");
+
+    private final String value;
+
+    NovelStatPeriodType(String value) {
+        this.value = value;
+    }
+
+    @Override
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    public static NovelStatPeriodType of(String value) {
+        return ValuedEnumHelper.fromValue(value, NovelStatPeriodType.class);
+    }
 }


### PR DESCRIPTION
## 🔖 연관된 이슈
- #34
## 🧾 작업 내용
- NovelStatPeriodType enum 값의 value(축약형)로 db에 저장될 수 있도록 converter 구현
- NovelPeriodStat 엔티티의 periodType 필드에 해당 Converter 적용
