### PR TITLE
Feature: 원인 없이 에러 응답 시 로직 개선

### DIFF
--- a/novelservice/src/main/java/com/iucyh/novelservice/common/exception/ServiceException.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/common/exception/ServiceException.java
@@ -22,6 +22,6 @@ public abstract class ServiceException extends RuntimeException {
     }
 
     protected ServiceException(ErrorCode errorCode) {
-        this(errorCode, errorCode.getDefaultMessage(), Map.of());
+        this(errorCode, errorCode.getDefaultMessage(), null);
     }
 }

--- a/novelservice/src/main/java/com/iucyh/novelservice/common/response/api/FailResponse.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/common/response/api/FailResponse.java
@@ -23,6 +23,6 @@ public class FailResponse {
         this.code = errorCode.getCode();
         this.message = message;
         this.path = path;
-        this.causes = causes == null ? Map.of() : causes;
+        this.causes = causes;
     }
 }


### PR DESCRIPTION
## 🔖 연관된 이슈
- #37 
## 🧾 작업 내용
- FailResponse 생성자에서 causes null 체크 로직 삭제
- ServiceException의 causes 를 받지 않는 생성자에서 causes 를 null 로 설정하도록 변경
