### PR TITLE
[build] QueryDSL 5.0.0 -> openfeign/QueryDSL 7.1 로 마이그레이션

### DIFF
--- a/novelservice/build.gradle
+++ b/novelservice/build.gradle
@@ -23,26 +23,49 @@ repositories {
 	mavenCentral()
 }
 
+def jnanoidVersion = '2.0.0'
+def querydslVersion = '7.1'
+def querydslSrcDir = layout.buildDirectory.dir("generated/querydsl")
+
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	// spring
+	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'com.h2database:h2'
-	annotationProcessor 'org.projectlombok:lombok'
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
-	implementation "com.querydsl:querydsl-jpa:5.0.0:jakarta"
-	annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
-	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
-	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+	// lombok
+	compileOnly 'org.projectlombok:lombok'
+	annotationProcessor 'org.projectlombok:lombok'
 
-	implementation 'com.aventrix.jnanoid:jnanoid:2.0.0'
+	// database
+	runtimeOnly 'com.h2database:h2'
+
+	// querydsl
+	implementation "io.github.openfeign.querydsl:querydsl-jpa:${querydslVersion}"
+	annotationProcessor "io.github.openfeign.querydsl:querydsl-apt:${querydslVersion}:jpa"
+	annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
+
+	// nanoid
+	implementation "com.aventrix.jnanoid:jnanoid:${jnanoidVersion}"
+}
+
+sourceSets {
+	main {
+		java {
+			srcDirs += querydslSrcDir
+		}
+	}
 }
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+tasks.withType(JavaCompile).configureEach {
+	options.generatedSourceOutputDirectory.set(querydslSrcDir)
 }


### PR DESCRIPTION
## 🔖 연관된 이슈

## 🧾 작업 내용
- QueryDSL 5.0.0 버전의 SQL Injection 취약점을 보완하기 위해 openfeign의 QueryDSL 7.1 버전으로 마이그레이션
- 추가로 빌드 코드를 조금 정리하여 가독성 향상
