### PR TITLE
fix: 완결된 소설에 회차를 등록할 수 있는 버그 수정

### DIFF
--- a/novelservice/src/main/java/com/iucyh/novelservice/episode/service/EpisodeService.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/episode/service/EpisodeService.java
@@ -4,6 +4,7 @@ import com.iucyh.novelservice.episode.exception.EpisodeNotFound;
 import com.iucyh.novelservice.episode.service.dto.command.CreateEpisodeCommand;
 import com.iucyh.novelservice.episode.service.dto.command.UpdateEpisodeCommand;
 import com.iucyh.novelservice.episode.service.dto.mapper.EpisodeCommandMapper;
+import com.iucyh.novelservice.novel.exception.NovelAlreadyCompleted;
 import com.iucyh.novelservice.novel.exception.NovelNotFound;
 import com.iucyh.novelservice.episode.domain.Episode;
 import com.iucyh.novelservice.novel.domain.Novel;
@@ -28,8 +29,11 @@ public class EpisodeService {
 
     public EpisodeSummaryResponse createEpisode(CreateEpisodeCommand command) {
         Novel novel = findNovelWithUserId(command.userId(), command.novelPublicId());
-        int newEpisodeNumber = novel.getLastEpisodeNumber() + 1;
+        if (novel.isCompletedNovel()) {
+            throw new NovelAlreadyCompleted();
+        }
 
+        int newEpisodeNumber = novel.getLastEpisodeNumber() + 1;
         Episode episode = EpisodeCommandMapper.toEpisode(command, novel, newEpisodeNumber);
         Episode savedEpisode = episodeRepository.save(episode); // TODO: GlobalExceptionHandler에 DuplicateKeyException 핸들링 메서드 구현 (409)
         novel.updateLastEpisode(savedEpisode.getEpisodeNumber(), savedEpisode.getCreatedAt());

--- a/novelservice/src/main/java/com/iucyh/novelservice/novel/domain/Novel.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/novel/domain/Novel.java
@@ -65,6 +65,10 @@ public class Novel extends PublicEntity {
         return novel;
     }
 
+    public boolean isCompletedNovel() {
+        return isCompleted;
+    }
+
     public void updateTextMetaData(String title, String description) {
         if (title != null) {
             this.title = title.strip();

--- a/novelservice/src/main/java/com/iucyh/novelservice/novel/exception/NovelAlreadyCompleted.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/novel/exception/NovelAlreadyCompleted.java
@@ -1,0 +1,11 @@
+package com.iucyh.novelservice.novel.exception;
+
+import com.iucyh.novelservice.common.exception.ServiceException;
+import com.iucyh.novelservice.novel.exception.errorcode.NovelErrorCode;
+
+public class NovelAlreadyCompleted extends ServiceException {
+
+    public NovelAlreadyCompleted() {
+        super(NovelErrorCode.NOVEL_ALREADY_COMPLETED);
+    }
+}

--- a/novelservice/src/main/java/com/iucyh/novelservice/novel/exception/errorcode/NovelErrorCode.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/novel/exception/errorcode/NovelErrorCode.java
@@ -12,7 +12,8 @@ public enum NovelErrorCode implements ErrorCode {
     NOVEL_NOT_FOUND(HttpStatus.NOT_FOUND, "NOVEL-4041", "Novel not found with this id"),
     DUPLICATE_TITLE(HttpStatus.BAD_REQUEST, "NOVEL-4001", "Novel title already exists"),
     INVALID_CURSOR(HttpStatus.BAD_REQUEST, "NOVEL-4002", "Invalid paging cursor"),
-    NOVEL_HAS_NO_EPISODES(HttpStatus.BAD_REQUEST, "NOVEL-4003", "Novel doesn't have episodes");
+    NOVEL_HAS_NO_EPISODES(HttpStatus.BAD_REQUEST, "NOVEL-4003", "Novel doesn't have episodes"),
+    NOVEL_ALREADY_COMPLETED(HttpStatus.CONFLICT, "NOVEL-4091", "Novel already completed");
 
     private final HttpStatus status;
     private final String code;


### PR DESCRIPTION
## 🔖 연관된 이슈
- #52
## 🧾 작업 내용
- 회차를 등록하려는 소설이 완결된 상태라면 회차를 등록하지 못하도록 거부 로직 추가
