### PR TITLE
Fix: 소설 목록 조회 시 삭제된 유저의 소설이 노출되는 문제

### DIFF
--- a/novelservice/src/main/java/com/iucyh/novelservice/novel/repository/query/NovelQueryRepositoryImpl.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/novel/repository/query/NovelQueryRepositoryImpl.java
@@ -73,7 +73,8 @@ public class NovelQueryRepositoryImpl implements NovelQueryRepository {
 
     private BooleanExpression applyDefaultFilter() {
         return novel.deletedAt.isNull() // 삭제되지 않은 소설
-                .and(novel.lastEpisodeAt.isNotNull()); // 회차가 하나라도 존재하는 소설
+                .and(novel.lastEpisodeAt.isNotNull()) // 회차가 하나라도 존재하는 소설
+                .and(user.deletedAt.isNull()); // 작성자가 삭제되지 않은 소설
     }
 
     private BooleanExpression applyCategoryFilter(NovelCategory category) {


### PR DESCRIPTION
## 🔖 연관된 이슈
- #66 
## 🧾 작업 내용
- 소설 목록 조회 쿼리의 기본 필터에 soft delete 된 유저를 제외하는 조건 추가
