### PR TITLE
Refactoring: 섹션과 관련된 서비스 메서드 분리

### DIFF
--- a/novelservice/src/main/java/com/iucyh/novelservice/novel/service/NovelQueryService.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/novel/service/NovelQueryService.java
@@ -1,7 +1,6 @@
 package com.iucyh.novelservice.novel.service;
 
 import com.iucyh.novelservice.novel.domain.Novel;
-import com.iucyh.novelservice.novel.enumtype.NovelCategory;
 import com.iucyh.novelservice.common.response.PageWithCursorResponse;
 import com.iucyh.novelservice.novel.service.codec.NovelCursorCodec;
 import com.iucyh.novelservice.novel.service.dto.query.GetNewNovelsQuery;
@@ -29,22 +28,6 @@ public class NovelQueryService {
     private final NovelCursorCodec cursorCodec;
     private final NovelPagingStrategyFactory pagingStrategyFactory;
     private final NovelQueryRepository novelQueryRepository;
-
-    public List<NovelSummaryResponse> getPopularNovelsForSection(NovelCategory category) {
-        NovelPagingCondition pagingCondition = new NovelPagingCondition(null, 10);
-        NovelPagingStrategy strategy = pagingStrategyFactory.get(NovelSortType.POPULAR);
-        List<Novel> novels = novelQueryRepository.findNovels(pagingCondition, strategy, category);
-
-        return mapToNovelResponseList(novels);
-    }
-
-    public List<NovelSummaryResponse> getNewNovelsForSection() {
-        NovelPagingCondition pagingCondition = new NovelPagingCondition(null, 30);
-        NovelPagingStrategy strategy = pagingStrategyFactory.get(NovelSortType.LAST_UPDATE);
-        List<Novel> novels = novelQueryRepository.findNewNovels(pagingCondition, strategy, null);
-
-        return mapToNovelResponseList(novels);
-    }
 
     public PageWithCursorResponse<NovelSummaryResponse> getNovels(GetNovelsQuery query) {
         return findNovels(query.sortType(), query.cursor(), query.limit(),

--- a/novelservice/src/main/java/com/iucyh/novelservice/novel/service/NovelQueryService.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/novel/service/NovelQueryService.java
@@ -6,51 +6,33 @@ import com.iucyh.novelservice.common.response.PageWithCursorResponse;
 import com.iucyh.novelservice.novel.service.codec.NovelCursorCodec;
 import com.iucyh.novelservice.novel.service.dto.query.GetNewNovelsQuery;
 import com.iucyh.novelservice.novel.service.dto.query.GetNovelsQuery;
+import com.iucyh.novelservice.novel.service.factory.NovelPagingStrategyFactory;
 import com.iucyh.novelservice.novel.web.dto.mapper.NovelResponseMapper;
 import com.iucyh.novelservice.novel.web.dto.response.NovelSummaryResponse;
 import com.iucyh.novelservice.novel.enumtype.NovelSortType;
-import com.iucyh.novelservice.novel.repository.NovelRepository;
 import com.iucyh.novelservice.novel.repository.query.NovelQueryRepository;
 import com.iucyh.novelservice.novel.repository.query.condition.NovelPagingCondition;
 import com.iucyh.novelservice.novel.repository.query.paging.cursor.NovelCursor;
 import com.iucyh.novelservice.novel.repository.query.paging.NovelPagingStrategy;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.Map;
 import java.util.function.BiFunction;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 
 @Service
 @Transactional(readOnly = true)
+@RequiredArgsConstructor
 public class NovelQueryService {
 
     private final NovelCursorCodec cursorCodec;
+    private final NovelPagingStrategyFactory pagingStrategyFactory;
     private final NovelQueryRepository novelQueryRepository;
-    private final Map<NovelSortType, NovelPagingStrategy> pagingStrategyMap;
-
-    public NovelQueryService(
-            NovelCursorCodec cursorCodec,
-            NovelQueryRepository novelQueryRepository,
-            List<NovelPagingStrategy> pagingStrategies
-    ) {
-        this.cursorCodec = cursorCodec;
-        this.novelQueryRepository = novelQueryRepository;
-        this.pagingStrategyMap = pagingStrategies
-                .stream()
-                .collect(
-                        Collectors.toUnmodifiableMap(
-                                NovelPagingStrategy::getSupportedSortType,
-                                Function.identity()
-                        )
-                );
-    }
 
     public List<NovelSummaryResponse> getPopularNovelsForSection(NovelCategory category) {
         NovelPagingCondition pagingCondition = new NovelPagingCondition(null, 10);
-        NovelPagingStrategy strategy = getPagingStrategy(NovelSortType.POPULAR);
+        NovelPagingStrategy strategy = pagingStrategyFactory.get(NovelSortType.POPULAR);
         List<Novel> novels = novelQueryRepository.findNovels(pagingCondition, strategy, category);
 
         return mapToNovelResponseList(novels);
@@ -58,7 +40,7 @@ public class NovelQueryService {
 
     public List<NovelSummaryResponse> getNewNovelsForSection() {
         NovelPagingCondition pagingCondition = new NovelPagingCondition(null, 30);
-        NovelPagingStrategy strategy = getPagingStrategy(NovelSortType.LAST_UPDATE);
+        NovelPagingStrategy strategy = pagingStrategyFactory.get(NovelSortType.LAST_UPDATE);
         List<Novel> novels = novelQueryRepository.findNewNovels(pagingCondition, strategy, null);
 
         return mapToNovelResponseList(novels);
@@ -90,7 +72,7 @@ public class NovelQueryService {
             BiFunction<NovelPagingCondition, NovelPagingStrategy, List<Novel>> finder
     ) {
         NovelPagingCondition pagingCondition = createPagingCondition(sortType, cursor, limit + 1);
-        NovelPagingStrategy pagingStrategy = getPagingStrategy(sortType);
+        NovelPagingStrategy pagingStrategy = pagingStrategyFactory.get(sortType);
 
         List<Novel> result = finder.apply(pagingCondition, pagingStrategy);
 
@@ -108,14 +90,6 @@ public class NovelQueryService {
 
         List<NovelSummaryResponse> novels = mapToNovelResponseList(pageResult);
         return NovelResponseMapper.toPageResponse(novels, newCursor, limit);
-    }
-
-    private NovelPagingStrategy getPagingStrategy(NovelSortType sortType) {
-        NovelPagingStrategy pagingStrategy = pagingStrategyMap.get(sortType);
-        if (pagingStrategy == null) {
-            throw new IllegalArgumentException("There's no matched paging strategy with: " + sortType.name());
-        }
-        return pagingStrategy;
     }
 
     private NovelPagingCondition createPagingCondition(NovelSortType sortType, String encodedCursor, int limit) {

--- a/novelservice/src/main/java/com/iucyh/novelservice/novel/service/NovelQueryService.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/novel/service/NovelQueryService.java
@@ -28,18 +28,15 @@ import java.util.stream.Collectors;
 public class NovelQueryService {
 
     private final NovelCursorCodec cursorCodec;
-    private final NovelRepository novelRepository;
     private final NovelQueryRepository novelQueryRepository;
     private final Map<NovelSortType, NovelPagingStrategy> pagingStrategyMap;
 
     public NovelQueryService(
             NovelCursorCodec cursorCodec,
-            NovelRepository novelRepository,
             NovelQueryRepository novelQueryRepository,
             List<NovelPagingStrategy> pagingStrategies
     ) {
         this.cursorCodec = cursorCodec;
-        this.novelRepository = novelRepository;
         this.novelQueryRepository = novelQueryRepository;
         this.pagingStrategyMap = pagingStrategies
                 .stream()

--- a/novelservice/src/main/java/com/iucyh/novelservice/novel/service/factory/NovelPagingStrategyFactory.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/novel/service/factory/NovelPagingStrategyFactory.java
@@ -1,0 +1,4 @@
+package com.iucyh.novelservice.novel.service.factory;
+
+public class NovelPagingStrategyFactory {
+}

--- a/novelservice/src/main/java/com/iucyh/novelservice/novel/service/factory/NovelPagingStrategyFactory.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/novel/service/factory/NovelPagingStrategyFactory.java
@@ -3,7 +3,6 @@ package com.iucyh.novelservice.novel.service.factory;
 import com.iucyh.novelservice.novel.enumtype.NovelSortType;
 import com.iucyh.novelservice.novel.repository.query.paging.NovelPagingStrategy;
 import jakarta.annotation.PostConstruct;
-import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
@@ -13,7 +12,7 @@ import java.util.stream.Collectors;
 
 /**
  * <p>Novel의 페이징 전략을 조회하는 Factory</p>
- * <b>빈 생성 시 특정 NovelSortType과 매칭되는 전략이 없으면 에러 발생</b>
+ * <b>빈 생성 시 특정 NovelSortType과 매칭되는 전략이 없으면 {@code IllegalStateException} 발생</b>
  */
 @Component
 public class NovelPagingStrategyFactory {
@@ -40,6 +39,12 @@ public class NovelPagingStrategyFactory {
         }
     }
 
+    /**
+     * <p>{@code sortType}과 매칭되는 페이징 전략 조회</p>
+     * <b>빈 초기화 단계에서 각 {@code NovelSortType}과 매칭되는 전략이 있는지 검증하므로 null은 절대 반환되지 않음</b>
+     * @param sortType 조회 기준
+     * @return 전달된 {@code sortType}과 매칭되는 {@code NovelPagingStrategy}
+     */
     public NovelPagingStrategy get(NovelSortType sortType) {
         return pagingStrategyMap.get(sortType);
     }

--- a/novelservice/src/main/java/com/iucyh/novelservice/novel/service/factory/NovelPagingStrategyFactory.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/novel/service/factory/NovelPagingStrategyFactory.java
@@ -1,4 +1,46 @@
 package com.iucyh.novelservice.novel.service.factory;
 
+import com.iucyh.novelservice.novel.enumtype.NovelSortType;
+import com.iucyh.novelservice.novel.repository.query.paging.NovelPagingStrategy;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * <p>Novel의 페이징 전략을 조회하는 Factory</p>
+ * <b>빈 생성 시 특정 NovelSortType과 매칭되는 전략이 없으면 에러 발생</b>
+ */
+@Component
 public class NovelPagingStrategyFactory {
+
+    private final Map<NovelSortType, NovelPagingStrategy> pagingStrategyMap;
+
+    public NovelPagingStrategyFactory(List<NovelPagingStrategy> pagingStrategies) {
+        this.pagingStrategyMap = pagingStrategies
+                .stream()
+                .collect(
+                        Collectors.toUnmodifiableMap(
+                                NovelPagingStrategy::getSupportedSortType,
+                                Function.identity()
+                        )
+                );
+    }
+
+    @PostConstruct
+    private void validate() {
+        for (NovelSortType sortType : NovelSortType.values()) {
+            if (!pagingStrategyMap.containsKey(sortType)) {
+                throw new IllegalStateException("There's no matched paging strategy with: " + sortType.name());
+            }
+        }
+    }
+
+    public NovelPagingStrategy get(NovelSortType sortType) {
+        return pagingStrategyMap.get(sortType);
+    }
 }

--- a/novelservice/src/main/java/com/iucyh/novelservice/novel/web/dto/mapper/NovelRequestMapper.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/novel/web/dto/mapper/NovelRequestMapper.java
@@ -51,7 +51,7 @@ public class NovelRequestMapper {
         return new GetNovelsQuery(
                 category,
                 request.sort(),
-                request.cursor(),
+                request.next(),
                 request.size()
         );
     }
@@ -60,7 +60,7 @@ public class NovelRequestMapper {
         return new GetNewNovelsQuery(
                 category,
                 request.sort(),
-                request.cursor(),
+                request.next(),
                 request.size()
         );
     }

--- a/novelservice/src/main/java/com/iucyh/novelservice/section/service/SectionQueryService.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/section/service/SectionQueryService.java
@@ -1,0 +1,47 @@
+package com.iucyh.novelservice.section.service;
+
+import com.iucyh.novelservice.novel.domain.Novel;
+import com.iucyh.novelservice.novel.enumtype.NovelCategory;
+import com.iucyh.novelservice.novel.enumtype.NovelSortType;
+import com.iucyh.novelservice.novel.repository.query.NovelQueryRepository;
+import com.iucyh.novelservice.novel.repository.query.condition.NovelPagingCondition;
+import com.iucyh.novelservice.novel.repository.query.paging.NovelPagingStrategy;
+import com.iucyh.novelservice.novel.service.factory.NovelPagingStrategyFactory;
+import com.iucyh.novelservice.novel.web.dto.mapper.NovelResponseMapper;
+import com.iucyh.novelservice.novel.web.dto.response.NovelSummaryResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class SectionQueryService {
+
+    private final NovelPagingStrategyFactory pagingStrategyFactory;
+    private final NovelQueryRepository novelQueryRepository;
+
+    public List<NovelSummaryResponse> getPopularNovels(NovelCategory category) {
+        NovelPagingCondition pagingCondition = new NovelPagingCondition(null, 10);
+        NovelPagingStrategy strategy = pagingStrategyFactory.get(NovelSortType.POPULAR);
+        List<Novel> novels = novelQueryRepository.findNovels(pagingCondition, strategy, category);
+
+        return mapToNovelResponseList(novels);
+    }
+
+    public List<NovelSummaryResponse> getNewNovels() {
+        NovelPagingCondition pagingCondition = new NovelPagingCondition(null, 30);
+        NovelPagingStrategy strategy = pagingStrategyFactory.get(NovelSortType.LAST_UPDATE);
+        List<Novel> novels = novelQueryRepository.findNewNovels(pagingCondition, strategy, null);
+
+        return mapToNovelResponseList(novels);
+    }
+
+    private List<NovelSummaryResponse> mapToNovelResponseList(List<Novel> novels) {
+        return novels.stream()
+                .map(NovelResponseMapper::toNovelSummaryResponse)
+                .toList();
+    }
+}

--- a/novelservice/src/main/java/com/iucyh/novelservice/section/web/controller/SectionController.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/section/web/controller/SectionController.java
@@ -3,8 +3,8 @@ package com.iucyh.novelservice.section.web.controller;
 import com.iucyh.novelservice.common.response.api.ApiResponseMapper;
 import com.iucyh.novelservice.common.response.api.SuccessResponse;
 import com.iucyh.novelservice.novel.enumtype.NovelCategory;
-import com.iucyh.novelservice.novel.service.NovelQueryService;
 import com.iucyh.novelservice.novel.web.dto.response.NovelSummaryResponse;
+import com.iucyh.novelservice.section.service.SectionQueryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -18,19 +18,19 @@ import java.util.List;
 @RequiredArgsConstructor
 public class SectionController {
 
-    private final NovelQueryService novelQueryService;
+    private final SectionQueryService sectionQueryService;
 
     @GetMapping("/popular")
-    public SuccessResponse<List<NovelSummaryResponse>> getPopularNovelsForSection(
+    public SuccessResponse<List<NovelSummaryResponse>> getPopularNovels(
             @RequestParam(required = false) NovelCategory category
     ) {
-        List<NovelSummaryResponse> result = novelQueryService.getPopularNovelsForSection(category);
+        List<NovelSummaryResponse> result = sectionQueryService.getPopularNovels(category);
         return ApiResponseMapper.success(result);
     }
 
     @GetMapping("/new")
-    public SuccessResponse<List<NovelSummaryResponse>> getNewNovelsForSection() {
-        List<NovelSummaryResponse> result = novelQueryService.getNewNovelsForSection();
+    public SuccessResponse<List<NovelSummaryResponse>> getNewNovels() {
+        List<NovelSummaryResponse> result = sectionQueryService.getNewNovels();
         return ApiResponseMapper.success(result);
     }
 }


### PR DESCRIPTION
## 🔖 연관된 이슈
- #68 
## 🧾 작업 내용
- NovelQueryService의 메서드 중 SectionController 에서 쓰이는 메서드를 별도의 SectionQueryService 로 분리
- 소설의 페이징 전략을 조회하는 Factory 를 구현하여 여러곳에서 최소한의 의존성으로 전략을 쉽게 조회할 수 있도록 개선
