### PR TITLE
Feature: 부모 엔티티 삭제 시 자식 엔티티도 같이 삭제

### DIFF
--- a/novelservice/src/main/java/com/iucyh/novelservice/episode/repository/EpisodeRepository.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/episode/repository/EpisodeRepository.java
@@ -20,7 +20,6 @@ public interface EpisodeRepository extends PublicEntityRepository<Episode, Long>
      * <p>{@code publicId}에 해당하는 회차를 조회하면서 아래 조건들을 동시에 검사</p>
      * <ul>
      *     <li>회차가 삭제되지 않았는지 여부</li>
-     *     <li>회차가 속한 소설이 삭제되지 않았는지 여부</li>
      *     <li>회차가 속한 소설의 작성자 id가 {@code userId}와 일치하는지 여부</li>
      * </ul>
      */
@@ -29,8 +28,9 @@ public interface EpisodeRepository extends PublicEntityRepository<Episode, Long>
     from Episode e
     join e.novel n
     where
-        e.publicId = :publicId and e.deletedAt is null
-        and n.user.id = :userId and n.deletedAt is null
+        e.publicId = :publicId
+        and e.deletedAt is null
+        and n.user.id = :userId
     """)
     Optional<Episode> findByPublicIdWithNovelUser(@Param("publicId") String publicId, @Param("userId") Long userId);
 
@@ -38,7 +38,6 @@ public interface EpisodeRepository extends PublicEntityRepository<Episode, Long>
      * <p>{@code publicId}에 해당하는 회차를 조회하면서 아래 조건들을 동시에 검사</p>
      * <ul>
      *     <li>회차가 삭제되지 않았는지 여부</li>
-     *     <li>회차가 속한 소설이 삭제되지 않았는지 여부</li>
      *     <li>회차가 속한 소설의 작성자 id가 {@code userId}와 일치하는지 여부</li>
      * </ul>
      * <b>주의: 조회 시 Novel 엔티티도 같이 조회 (fetch join), 이후 로직에서 Novel 엔티티가 필요 없다면 Fetch 가 붙지 않은 메서드 사용 권장</b>
@@ -48,8 +47,9 @@ public interface EpisodeRepository extends PublicEntityRepository<Episode, Long>
     from Episode e
     join fetch e.novel n
     where
-        e.publicId = :publicId and e.deletedAt is null
-        and n.user.id = :userId and n.deletedAt is null
+        e.publicId = :publicId
+        and e.deletedAt is null
+        and n.user.id = :userId
     """)
     Optional<Episode> findByPublicIdWithNovelUserFetch(@Param("publicId") String publicId, @Param("userId") Long userId);
 
@@ -58,7 +58,8 @@ public interface EpisodeRepository extends PublicEntityRepository<Episode, Long>
     void increaseViewCount(@Param("episodeId") Long episodeId);
 
     /**
-     * 특정 Novel에 속하는 회차들을 bulk update 로 soft delete 처리
+     * <p>특정 Novel에 속하는 회차들을 bulk update 로 soft delete 처리</p>
+     * <b>이미 삭제된 회차들은 무시</b>
      * @param novelId 삭제할 회차들이 속한 Novel의 pk
      * @param deletedAt 각 Episode에 기록될 삭제 시간, 가급적 현재 시간 혹은 부모 Novel의 삭제 시간 전달 권장
      */
@@ -66,7 +67,7 @@ public interface EpisodeRepository extends PublicEntityRepository<Episode, Long>
     @Query("""
     update Episode e
     set e.deletedAt = :deletedAt
-    where e.novel.id = :novelId
+    where e.novel.id = :novelId and e.deletedAt is null
     """)
     void softDeleteByNovelId(Long novelId, LocalDateTime deletedAt);
 }

--- a/novelservice/src/main/java/com/iucyh/novelservice/episode/repository/EpisodeRepository.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/episode/repository/EpisodeRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 public interface EpisodeRepository extends PublicEntityRepository<Episode, Long> {
@@ -55,4 +56,17 @@ public interface EpisodeRepository extends PublicEntityRepository<Episode, Long>
     @Modifying(clearAutomatically = true)
     @Query("update Episode e set e.viewCount = e.viewCount + 1 where e.id = :episodeId and e.deletedAt is null")
     void increaseViewCount(@Param("episodeId") Long episodeId);
+
+    /**
+     * 특정 Novel에 속하는 회차들을 bulk update 로 soft delete 처리
+     * @param novelId 삭제할 회차들이 속한 Novel의 pk
+     * @param deletedAt 각 Episode에 기록될 삭제 시간, 가급적 현재 시간 혹은 부모 Novel의 삭제 시간 전달 권장
+     */
+    @Modifying(clearAutomatically = true)
+    @Query("""
+    update Episode e
+    set e.deletedAt = :deletedAt
+    where e.novel.id = :novelId
+    """)
+    void softDeleteByNovelId(Long novelId, LocalDateTime deletedAt);
 }

--- a/novelservice/src/main/java/com/iucyh/novelservice/episode/repository/query/EpisodeQueryRepository.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/episode/repository/query/EpisodeQueryRepository.java
@@ -38,7 +38,7 @@ public interface EpisodeQueryRepository {
 
     /**
      * <p>{@code publicId}에 해당하는 회차의 상세 정보를 조회 (소설, 유저의 일부 정보 포함)</p>
-     * <p>회차, 소설, 유저 중 하나라도 삭제되었다면(soft delete 포함) Optional.empty() 반환</p>
+     * <p>회차가 삭제되었다면(soft delete 포함) Optional.empty() 반환</p>
      * @param publicId 조회할 회차의 public id
      * @return 회차의 상세 정보, 조건에 맞는 episode가 없다면 {@code Optional.empty()}
      */
@@ -46,7 +46,7 @@ public interface EpisodeQueryRepository {
 
     /**
      * <p>{@code publicId}에 해당하는 회차의 본문을 조회</p>
-     * <p>회차, 소설, 유저 중 하나라도 삭제되었다면(soft delete 포함) Optional.empty() 반환</p>
+     * <p>회차가 삭제되었다면(soft delete 포함) Optional.empty() 반환</p>
      * @param publicId 조회할 회차의 public id
      * @return 회차의 본문, 조건에 맞는 episode가 없다면 {@code Optional.empty()}
      */

--- a/novelservice/src/main/java/com/iucyh/novelservice/episode/repository/query/EpisodeQueryRepositoryImpl.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/episode/repository/query/EpisodeQueryRepositoryImpl.java
@@ -111,7 +111,7 @@ public class EpisodeQueryRepositoryImpl implements EpisodeQueryRepository {
                 .join(novel.user, user)
                 .where(
                         episode.publicId.eq(publicId),
-                        applyValidEpisodeFilter()
+                        episode.deletedAt.isNull()
                 )
                 .fetchOne();
         return Optional.ofNullable(result);
@@ -122,11 +122,9 @@ public class EpisodeQueryRepositoryImpl implements EpisodeQueryRepository {
         String result = queryFactory
                 .select(episode.content)
                 .from(episode)
-                .join(episode.novel, novel)
-                .join(novel.user, user)
                 .where(
                         episode.publicId.eq(publicId),
-                        applyValidEpisodeFilter()
+                        episode.deletedAt.isNull()
                 )
                 .fetchOne();
         return Optional.ofNullable(result);
@@ -172,21 +170,5 @@ public class EpisodeQueryRepositoryImpl implements EpisodeQueryRepository {
 
     private OrderSpecifier<Integer> applyOrder(EpisodeSortType sortType) {
         return sortType == EpisodeSortType.ASC ? episode.episodeNumber.asc() : episode.episodeNumber.desc();
-    }
-
-    /**
-     * <p>조회할 회차가 유효한 회차인지 검사하기 위한 필터 적용</p>
-     * <p>필터 조건</p>
-     * <ul>
-     *     <li>삭제되지 않은 회차</li>
-     *     <li>회차가 속한 소설이 삭제되지 않은 상태</li>
-     *     <li>회차가 속한 소설의 작성자가 삭제되지 않은 상태</li>
-     * </ul>
-     * <b>주의: novel, user와 관련된 조건을 사용하므로 쿼리에서 novel, user JOIN 필수</b>
-     */
-    private BooleanExpression applyValidEpisodeFilter() {
-        return episode.deletedAt.isNull()
-                .and(novel.deletedAt.isNull())
-                .and(user.deletedAt.isNull());
     }
 }

--- a/novelservice/src/main/java/com/iucyh/novelservice/episode/service/EpisodeService.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/episode/service/EpisodeService.java
@@ -13,7 +13,6 @@ import com.iucyh.novelservice.novel.exception.NovelNotFound;
 import com.iucyh.novelservice.episode.domain.Episode;
 import com.iucyh.novelservice.novel.domain.Novel;
 import com.iucyh.novelservice.episode.web.dto.mapper.EpisodeResponseMapper;
-import com.iucyh.novelservice.episode.web.dto.response.EpisodeSummaryResponse;
 import com.iucyh.novelservice.episode.repository.EpisodeRepository;
 import com.iucyh.novelservice.novel.repository.NovelRepository;
 import lombok.RequiredArgsConstructor;

--- a/novelservice/src/main/java/com/iucyh/novelservice/novel/repository/NovelRepository.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/novel/repository/NovelRepository.java
@@ -17,7 +17,7 @@ public interface NovelRepository extends PublicEntityRepository<Novel, Long> {
 
     /**
      * <p>{@code publicId}에 해당하는 소설 조회</p>
-     * <p>소설이 삭제되었거나 유저가 삭제되었다면(soft delete 포함) {@code Optional.emtpy()} 반환</p>
+     * <p>소설이 삭제되었다면(soft delete 포함) {@code Optional.emtpy()} 반환</p>
      * <b>조회 시 User 엔티티도 같이 조회(fetch join)</b>
      * @param publicId 조회할 Novel의 public id
      */
@@ -28,7 +28,6 @@ public interface NovelRepository extends PublicEntityRepository<Novel, Long> {
     where
         n.publicId = :publicId
         and n.deletedAt is null
-        and u.deletedAt is null
     """)
     Optional<Novel> findByPublicIdFetch(@Param("publicId") String publicId);
 

--- a/novelservice/src/main/java/com/iucyh/novelservice/novel/repository/query/NovelQueryRepository.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/novel/repository/query/NovelQueryRepository.java
@@ -14,7 +14,6 @@ public interface NovelQueryRepository {
      * <ul>
      *     <li>{@code publicId}에 해당하는 소설</li>
      *     <li>삭제되지 않은 소설</li>
-     *     <li>소설의 작성자가 삭제되지 않은 상태</li>
      * </ul>
      * @param publicId 검사할 소설의 public id
      * @return 조건을 충족하는 소설이 존재하면 {@code true}, 아니라면 {@code false}

--- a/novelservice/src/main/java/com/iucyh/novelservice/novel/repository/query/NovelQueryRepositoryImpl.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/novel/repository/query/NovelQueryRepositoryImpl.java
@@ -27,11 +27,9 @@ public class NovelQueryRepositoryImpl implements NovelQueryRepository {
         Integer result = queryFactory
                 .selectOne()
                 .from(novel)
-                .join(novel.user, user)
                 .where(
                         novel.publicId.eq(publicId),
-                        novel.deletedAt.isNull(),
-                        user.deletedAt.isNull()
+                        novel.deletedAt.isNull()
                 )
                 .fetchFirst();
         return result != null;
@@ -43,7 +41,7 @@ public class NovelQueryRepositoryImpl implements NovelQueryRepository {
                 .selectFrom(novel)
                 .join(novel.user, user).fetchJoin()
                 .where(
-                        applyDefaultFilter(),
+                        applyValidNovelFilter(),
                         applyCategoryFilter(category)
                 )
                 .limit(condition.limit());
@@ -60,7 +58,7 @@ public class NovelQueryRepositoryImpl implements NovelQueryRepository {
                 .selectFrom(novel)
                 .join(novel.user, user).fetchJoin()
                 .where(
-                        applyDefaultFilter(),
+                        applyValidNovelFilter(),
                         applyCategoryFilter(category),
                         novel.createdAt.goe(thisMonth)
                 )
@@ -71,10 +69,17 @@ public class NovelQueryRepositoryImpl implements NovelQueryRepository {
                 .fetch();
     }
 
-    private BooleanExpression applyDefaultFilter() {
-        return novel.deletedAt.isNull() // 삭제되지 않은 소설
-                .and(novel.lastEpisodeAt.isNotNull()) // 회차가 하나라도 존재하는 소설
-                .and(user.deletedAt.isNull()); // 작성자가 삭제되지 않은 소설
+    /**
+     * <p>조회할 소설이 유효한 소설인지 검사하기 위한 필터 적용</p>
+     * <p>필터 조건</p>
+     * <ul>
+     *     <li>삭제되지 않은 소설</li>
+     *     <li>회차가 한개라도 존재하는(== 최신 회차 등록일이 null이 아닌) 소설</li>
+     * </ul>
+     */
+    private BooleanExpression applyValidNovelFilter() {
+        return novel.deletedAt.isNull()
+                .and(novel.lastEpisodeAt.isNotNull());
     }
 
     private BooleanExpression applyCategoryFilter(NovelCategory category) {

--- a/novelservice/src/main/java/com/iucyh/novelservice/novel/service/NovelService.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/novel/service/NovelService.java
@@ -101,6 +101,8 @@ public class NovelService {
     public void deleteNovel(DeleteNovelCommand command) {
         Novel novel = findNovelWithUserId(command.userId(), command.novelPublicId());
         novel.softDelete();
+        // 연관된 자식 엔티티 삭제 (bulk update)
+        episodeRepository.softDeleteByNovelId(novel.getId(), novel.getDeletedAt());
     }
 
     private User findUserById(long userId) {


### PR DESCRIPTION
## 🔖 연관된 이슈
- #76 
## 🧾 작업 내용
- Novel 삭제 시 해당 Novel에 속한 Episode들도 같이 삭제하도록 변경
- Novel, Episode 조회 쿼리에서 부모가 삭제되었는지 검사하는 조건 삭제
