### PR TITLE
Feature: HTML로 저장되는 필드에 대한 xss 방어 및 전용 길이 검증 로직 구현

### DIFF
--- a/novelservice/build.gradle
+++ b/novelservice/build.gradle
@@ -24,6 +24,7 @@ repositories {
 }
 
 def jnanoidVersion = '2.0.0'
+def htmlSanitizerVersion = '20220608.1'
 def querydslVersion = '7.1'
 def querydslSrcDir = layout.buildDirectory.dir("generated/querydsl")
 
@@ -52,6 +53,9 @@ dependencies {
 
 	// nanoid
 	implementation "com.aventrix.jnanoid:jnanoid:${jnanoidVersion}"
+
+	// html sanitizer
+	implementation "com.googlecode.owasp-java-html-sanitizer:owasp-java-html-sanitizer:${htmlSanitizerVersion}"
 }
 
 sourceSets {

--- a/novelservice/build.gradle
+++ b/novelservice/build.gradle
@@ -24,7 +24,7 @@ repositories {
 }
 
 def jnanoidVersion = '2.0.0'
-def htmlSanitizerVersion = '20220608.1'
+def jsoupVersion = '1.21.2'
 def querydslVersion = '7.1'
 def querydslSrcDir = layout.buildDirectory.dir("generated/querydsl")
 
@@ -54,8 +54,8 @@ dependencies {
 	// nanoid
 	implementation "com.aventrix.jnanoid:jnanoid:${jnanoidVersion}"
 
-	// html sanitizer
-	implementation "com.googlecode.owasp-java-html-sanitizer:owasp-java-html-sanitizer:${htmlSanitizerVersion}"
+	// jsoup
+	implementation "org.jsoup:jsoup:${jsoupVersion}"
 }
 
 sourceSets {

--- a/novelservice/src/main/java/com/iucyh/novelservice/common/deserializer/html/HtmlDeserializer.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/common/deserializer/html/HtmlDeserializer.java
@@ -1,0 +1,64 @@
+package com.iucyh.novelservice.common.deserializer.html;
+
+import com.fasterxml.jackson.core.JacksonException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.BeanProperty;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.deser.ContextualDeserializer;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.iucyh.novelservice.common.util.htmlsanitizer.HtmlContentType;
+import com.iucyh.novelservice.common.util.htmlsanitizer.HtmlSanitizerUtil;
+
+import java.io.IOException;
+
+/**
+ * <p>JSON의 HTML 문자열 필드를 역직렬화 단계에서 규칙에 맞게 정제(sanitize) 및 정규화</p>
+ * <p>Request DTO의 필드 중 HTML 정제가 필요한 필드에 사용</p>
+ * <b>주의: {@code @HtmlSanitized}를 같이 쓰지 않을 시 원본 문자열 반환</b>
+ */
+public class HtmlDeserializer extends StdDeserializer<String> implements ContextualDeserializer {
+
+    private final HtmlContentType contentType;
+
+    public HtmlDeserializer() {
+        super(String.class);
+        this.contentType = null;
+    }
+
+    private HtmlDeserializer(HtmlContentType contentType) {
+        super(String.class);
+        this.contentType = contentType;
+    }
+
+    @Override
+    public JsonDeserializer<?> createContextual(DeserializationContext ctxt, BeanProperty property) throws JsonMappingException {
+        if (property == null) {
+            return new HtmlDeserializer();
+        }
+
+        HtmlSanitized annotation = property.getAnnotation(HtmlSanitized.class);
+        if (annotation == null) {
+            return new HtmlDeserializer();
+        }
+
+        return new HtmlDeserializer(annotation.value());
+    }
+
+
+    @Override
+    public String deserialize(JsonParser p, DeserializationContext ctxt) throws IOException, JacksonException {
+        String value = p.getValueAsString();
+
+        if (value == null) {
+            return null;
+        }
+
+        if (contentType == null) {
+            return value;
+        }
+
+        return HtmlSanitizerUtil.sanitize(contentType, value);
+    }
+}

--- a/novelservice/src/main/java/com/iucyh/novelservice/common/deserializer/html/HtmlSanitized.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/common/deserializer/html/HtmlSanitized.java
@@ -1,0 +1,21 @@
+package com.iucyh.novelservice.common.deserializer.html;
+
+import com.iucyh.novelservice.common.util.htmlsanitizer.HtmlContentType;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * <p>정제할 필드의 컨텐트 종류를 명시하기 위한 어노테이션</p>
+ */
+@Target({ ElementType.FIELD })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface HtmlSanitized {
+
+    /**
+     * 필드의 컨텐트 종류 (회차 본문, 공지사항 본문 등)
+     */
+    HtmlContentType value();
+}

--- a/novelservice/src/main/java/com/iucyh/novelservice/common/util/htmlsanitizer/HtmlContentType.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/common/util/htmlsanitizer/HtmlContentType.java
@@ -1,0 +1,9 @@
+package com.iucyh.novelservice.common.util.htmlsanitizer;
+
+/**
+ * 정제할 HTML 컨텐트의 종류
+ */
+public enum HtmlContentType {
+
+    EPISODE_CONTENT
+}

--- a/novelservice/src/main/java/com/iucyh/novelservice/common/util/htmlsanitizer/HtmlSanitizerUtil.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/common/util/htmlsanitizer/HtmlSanitizerUtil.java
@@ -20,12 +20,17 @@ public class HtmlSanitizerUtil {
 
     /**
      * <p>전달된 HTML 문자열을 내용의 종류에 따라 적절히 정제</p>
+     * <p>전달된 문자열이 비어있거나, {@code null}이라면 그 값 그대로 반환</p>
      * @param type 정제할 문자열 내용의 종류 (회차 본문, 공지사항 본문 등)
      * @param html 정제할 문자열
      * @return 규칙에 맞게 정제된 HTML 문자열
      */
     public static String sanitize(HtmlContentType type, String html) {
-        if (html == null || html.isBlank()) {
+        if (html == null) {
+            return null;
+        }
+
+        if (html.isBlank()) {
             return "";
         }
 

--- a/novelservice/src/main/java/com/iucyh/novelservice/common/util/htmlsanitizer/HtmlSanitizerUtil.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/common/util/htmlsanitizer/HtmlSanitizerUtil.java
@@ -1,0 +1,35 @@
+package com.iucyh.novelservice.common.util.htmlsanitizer;
+
+import org.jsoup.Jsoup;
+import org.jsoup.safety.Safelist;
+
+import java.util.Map;
+
+/**
+ * <p>HTML 태그 중 규칙에 맞지 않는 태그, 악성 스크립트 등을 정제하는 유틸리티</p>
+ */
+public class HtmlSanitizerUtil {
+
+    private static final Map<HtmlContentType, Safelist> safelistMap = Map.of(
+            HtmlContentType.EPISODE_CONTENT,
+            new Safelist()
+                    .addTags("p", "b", "strong", "i", "em", "u", "br", "span")
+    );
+
+    private HtmlSanitizerUtil() {}
+
+    /**
+     * <p>전달된 HTML 문자열을 내용의 종류에 따라 적절히 정제</p>
+     * @param type 정제할 문자열 내용의 종류 (회차 본문, 공지사항 본문 등)
+     * @param html 정제할 문자열
+     * @return 규칙에 맞게 정제된 HTML 문자열
+     */
+    public static String sanitize(HtmlContentType type, String html) {
+        if (html == null || html.isBlank()) {
+            return "";
+        }
+
+        Safelist safelist = safelistMap.get(type);
+        return Jsoup.clean(html, safelist);
+    }
+}

--- a/novelservice/src/main/java/com/iucyh/novelservice/common/validator/html/SizeWithoutHtml.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/common/validator/html/SizeWithoutHtml.java
@@ -26,7 +26,7 @@ public @interface SizeWithoutHtml {
      */
     int max() default Integer.MAX_VALUE;
 
-    String message() default "Value cannot be blank";
+    String message() default "Size must be between {min} and {max}";
 
     Class<?>[] groups() default {};
 

--- a/novelservice/src/main/java/com/iucyh/novelservice/common/validator/html/SizeWithoutHtml.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/common/validator/html/SizeWithoutHtml.java
@@ -1,0 +1,34 @@
+package com.iucyh.novelservice.common.validator.html;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.*;
+
+/**
+ * <p>HTML 태그를 모두 제외한 순수한 텍스트의 길이를 검증</p>
+ * <p>String 타입에만 사용 가능</p>
+ * <b>주의: 검증 대상 값이 null 인 경우 무시 -> 필요 시 NotNull 등의 null 검증 어노테이션과 같이 쓰기를 권장</b>
+ */
+@Target({ ElementType.FIELD })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Constraint(validatedBy = SizeWithoutHtmlValidator.class)
+public @interface SizeWithoutHtml {
+
+    /**
+     * <p>문자열의 최소 길이</p>
+     */
+    int min() default 0;
+
+    /**
+     * <p>문자열의 최대 길이</p>
+     */
+    int max() default Integer.MAX_VALUE;
+
+    String message() default "Value cannot be blank";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/novelservice/src/main/java/com/iucyh/novelservice/common/validator/html/SizeWithoutHtmlValidator.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/common/validator/html/SizeWithoutHtmlValidator.java
@@ -1,0 +1,27 @@
+package com.iucyh.novelservice.common.validator.html;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import org.jsoup.Jsoup;
+
+public class SizeWithoutHtmlValidator implements ConstraintValidator<SizeWithoutHtml, String> {
+
+    private int min;
+    private int max;
+
+    @Override
+    public void initialize(SizeWithoutHtml constraintAnnotation) {
+        this.min = constraintAnnotation.min();
+        this.max = constraintAnnotation.max();
+    }
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        if (value == null) {
+            return true;
+        }
+
+        String parsedText = Jsoup.parse(value).wholeText();
+        return parsedText.length() >= min && parsedText.length() <= max;
+    }
+}

--- a/novelservice/src/main/java/com/iucyh/novelservice/episode/web/dto/request/CreateEpisodeRequest.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/episode/web/dto/request/CreateEpisodeRequest.java
@@ -1,5 +1,10 @@
 package com.iucyh.novelservice.episode.web.dto.request;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.iucyh.novelservice.common.deserializer.html.HtmlDeserializer;
+import com.iucyh.novelservice.common.deserializer.html.HtmlSanitized;
+import com.iucyh.novelservice.common.util.htmlsanitizer.HtmlContentType;
+import com.iucyh.novelservice.common.validator.html.SizeWithoutHtml;
 import com.iucyh.novelservice.episode.constant.EpisodeConstants;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -18,6 +23,8 @@ public record CreateEpisodeRequest(
         String description,
 
         @NotBlank
-        @Size(min = EPISODE_CONTENT_LENGTH_MIN, max = EPISODE_CONTENT_LENGTH_MAX)
+        @SizeWithoutHtml(min = EPISODE_CONTENT_LENGTH_MIN, max = EPISODE_CONTENT_LENGTH_MAX)
+        @JsonDeserialize(using = HtmlDeserializer.class)
+        @HtmlSanitized(HtmlContentType.EPISODE_CONTENT)
         String content
 ) {}

--- a/novelservice/src/main/java/com/iucyh/novelservice/episode/web/dto/request/UpdateEpisodeContentRequest.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/episode/web/dto/request/UpdateEpisodeContentRequest.java
@@ -1,7 +1,11 @@
 package com.iucyh.novelservice.episode.web.dto.request;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.iucyh.novelservice.common.deserializer.html.HtmlDeserializer;
+import com.iucyh.novelservice.common.deserializer.html.HtmlSanitized;
+import com.iucyh.novelservice.common.util.htmlsanitizer.HtmlContentType;
+import com.iucyh.novelservice.common.validator.html.SizeWithoutHtml;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
 
 import static com.iucyh.novelservice.episode.constant.EpisodeConstants.EPISODE_CONTENT_LENGTH_MAX;
 import static com.iucyh.novelservice.episode.constant.EpisodeConstants.EPISODE_CONTENT_LENGTH_MIN;
@@ -9,6 +13,8 @@ import static com.iucyh.novelservice.episode.constant.EpisodeConstants.EPISODE_C
 public record UpdateEpisodeContentRequest(
 
         @NotNull
-        @Size(min = EPISODE_CONTENT_LENGTH_MIN, max = EPISODE_CONTENT_LENGTH_MAX)
+        @SizeWithoutHtml(min = EPISODE_CONTENT_LENGTH_MIN, max = EPISODE_CONTENT_LENGTH_MAX)
+        @JsonDeserialize(using = HtmlDeserializer.class)
+        @HtmlSanitized(HtmlContentType.EPISODE_CONTENT)
         String content
 ) {}


### PR DESCRIPTION
## 🔖 연관된 이슈
- #78 
## 🧾 작업 내용
- HTML Sanitizer 유틸 구현
- 회차 본문에 맞는 html 태그 white list 정의
- Json 역직렬화 시점에서 HTML Sanitization이 일어나도록 구현
- HTML 필드에 대해 길이 검증 시 HTML 태그를 제외하고 검증할 수 있도록 커스텀 Validator 구현
