### PR TITLE
Feature: 소설 완결 설정 가능 조건 수정

### DIFF
--- a/novelservice/src/main/java/com/iucyh/novelservice/episode/repository/query/EpisodeQueryRepository.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/episode/repository/query/EpisodeQueryRepository.java
@@ -1,5 +1,6 @@
 package com.iucyh.novelservice.episode.repository.query;
 
+import com.iucyh.novelservice.episode.enumtype.EpisodeType;
 import com.iucyh.novelservice.episode.repository.query.condition.EpisodePagingCondition;
 import com.iucyh.novelservice.episode.repository.query.projection.EpisodeDetailQueryProjection;
 import com.iucyh.novelservice.episode.repository.query.projection.EpisodePrevNextQueryProjection;
@@ -12,11 +13,11 @@ import java.util.Optional;
 public interface EpisodeQueryRepository {
 
     /**
-     * <p>{@code novelId}에 해당하는 소설에 프롤로그 회차가 존재하는지 검사</p>
+     * <p>{@code novelId}에 해당하는 소설에 종류가 {@code episodeType}인 회차가 존재하는지 검사</p>
      * @param novelId 검사할 소설의 id
-     * @return 해당 소설에 프롤로그 회차가 존재하면 {@code true}, 아니라면 {@code false}
+     * @return 조건이 맞는 회차가 존재하면 {@code true}, 아니라면 {@code false}
      */
-    boolean prologueExistsByNovelId(Long novelId);
+    boolean episodeExistsByNovelIdAndEpisodeType(Long novelId, EpisodeType episodeType);
 
     /**
      * <p>{@code publicId}에 해당하는 회차와 삭제된 회차를 제외한 나머지 회차 중 가장 최신 회차의 생성일 조회</p>

--- a/novelservice/src/main/java/com/iucyh/novelservice/episode/repository/query/EpisodeQueryRepositoryImpl.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/episode/repository/query/EpisodeQueryRepositoryImpl.java
@@ -30,13 +30,13 @@ public class EpisodeQueryRepositoryImpl implements EpisodeQueryRepository {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public boolean prologueExistsByNovelId(Long novelId) {
+    public boolean episodeExistsByNovelIdAndEpisodeType(Long novelId, EpisodeType episodeType) {
         Integer result = queryFactory
                 .selectOne()
                 .from(episode)
                 .where(
                         episode.novel.id.eq(novelId),
-                        episode.episodeType.eq(EpisodeType.PROLOGUE),
+                        episode.episodeType.eq(episodeType),
                         episode.deletedAt.isNull()
                 )
                 .fetchFirst();

--- a/novelservice/src/main/java/com/iucyh/novelservice/episode/service/EpisodeService.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/episode/service/EpisodeService.java
@@ -91,7 +91,7 @@ public class EpisodeService {
     }
 
     private EpisodeSaveResponse createPrologueEpisode(CreateEpisodeCommand command, Novel novel) {
-        boolean prologueExists = episodeQueryRepository.prologueExistsByNovelId(novel.getId());
+        boolean prologueExists = episodeQueryRepository.episodeExistsByNovelIdAndEpisodeType(novel.getId(), EpisodeType.PROLOGUE);
         if (prologueExists) { // 프롤로그는 소설 당 1개만 존재가능
             throw new NovelAlreadyHasPrologue();
         }

--- a/novelservice/src/main/java/com/iucyh/novelservice/novel/exception/NovelHasNoCommonEpisodes.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/novel/exception/NovelHasNoCommonEpisodes.java
@@ -3,9 +3,9 @@ package com.iucyh.novelservice.novel.exception;
 import com.iucyh.novelservice.common.exception.ServiceException;
 import com.iucyh.novelservice.novel.exception.errorcode.NovelErrorCode;
 
-public class NovelHasNoEpisodes extends ServiceException {
+public class NovelHasNoCommonEpisodes extends ServiceException {
 
-    public NovelHasNoEpisodes() {
-        super(NovelErrorCode.NOVEL_HAS_NO_EPISODES);
+    public NovelHasNoCommonEpisodes() {
+        super(NovelErrorCode.NOVEL_HAS_NO_COMMON_EPISODES);
     }
 }

--- a/novelservice/src/main/java/com/iucyh/novelservice/novel/exception/errorcode/NovelErrorCode.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/novel/exception/errorcode/NovelErrorCode.java
@@ -15,7 +15,7 @@ public enum NovelErrorCode implements ErrorCode {
 
     NOVEL_ALREADY_COMPLETED(HttpStatus.CONFLICT, "NOVEL-4091", "Novel already completed"),
     DUPLICATE_TITLE(HttpStatus.CONFLICT, "NOVEL-4092", "Novel title already exists"),
-    NOVEL_HAS_NO_EPISODES(HttpStatus.CONFLICT, "NOVEL-4093", "Novel doesn't have episodes"),
+    NOVEL_HAS_NO_COMMON_EPISODES(HttpStatus.CONFLICT, "NOVEL-4093", "Novel doesn't have common episodes"),
     NOVEL_ALREADY_HAS_PROLOGUE(HttpStatus.CONFLICT, "NOVEL-4094", "Novel already has prologue");
 
     private final HttpStatus status;

--- a/novelservice/src/main/java/com/iucyh/novelservice/novel/service/NovelService.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/novel/service/NovelService.java
@@ -1,6 +1,8 @@
 package com.iucyh.novelservice.novel.service;
 
+import com.iucyh.novelservice.episode.enumtype.EpisodeType;
 import com.iucyh.novelservice.episode.repository.EpisodeRepository;
+import com.iucyh.novelservice.episode.repository.query.EpisodeQueryRepository;
 import com.iucyh.novelservice.novel.exception.DuplicateNovelTitle;
 import com.iucyh.novelservice.novel.exception.NovelHasNoEpisodes;
 import com.iucyh.novelservice.novel.exception.NovelNotFound;
@@ -31,6 +33,7 @@ public class NovelService {
     private final UserRepository userRepository;
     private final NovelRepository novelRepository;
     private final EpisodeRepository episodeRepository;
+    private final EpisodeQueryRepository episodeQueryRepository;
 
     public NovelSaveResponse createNovel(CreateNovelCommand command) {
         long userId = command.userId();
@@ -74,8 +77,8 @@ public class NovelService {
 
         boolean isCompleted = command.isCompleted();
         if (isCompleted) {
-            boolean hasEpisodes = episodeRepository.existsByNovelIdAndDeletedAtIsNull(novel.getId());
-            if (!hasEpisodes) {
+            boolean hasCommonEpisodes = episodeQueryRepository.episodeExistsByNovelIdAndEpisodeType(novel.getId(), EpisodeType.COMMON);
+            if (!hasCommonEpisodes) { // 일반 회차가 한개라도 존재하지 않는다면 완결로 변경 불가
                 throw new NovelHasNoEpisodes();
             }
         }

--- a/novelservice/src/main/java/com/iucyh/novelservice/novel/service/NovelService.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/novel/service/NovelService.java
@@ -4,7 +4,7 @@ import com.iucyh.novelservice.episode.enumtype.EpisodeType;
 import com.iucyh.novelservice.episode.repository.EpisodeRepository;
 import com.iucyh.novelservice.episode.repository.query.EpisodeQueryRepository;
 import com.iucyh.novelservice.novel.exception.DuplicateNovelTitle;
-import com.iucyh.novelservice.novel.exception.NovelHasNoEpisodes;
+import com.iucyh.novelservice.novel.exception.NovelHasNoCommonEpisodes;
 import com.iucyh.novelservice.novel.exception.NovelNotFound;
 import com.iucyh.novelservice.novel.domain.Novel;
 import com.iucyh.novelservice.novel.service.dto.command.CreateNovelCommand;
@@ -16,7 +16,6 @@ import com.iucyh.novelservice.novel.web.dto.mapper.NovelResponseMapper;
 import com.iucyh.novelservice.novel.web.dto.response.NovelCompletionResponse;
 import com.iucyh.novelservice.novel.web.dto.response.NovelLikeCountResponse;
 import com.iucyh.novelservice.novel.web.dto.response.NovelSaveResponse;
-import com.iucyh.novelservice.novel.web.dto.response.NovelSummaryResponse;
 import com.iucyh.novelservice.novel.repository.NovelRepository;
 import com.iucyh.novelservice.user.domain.User;
 import com.iucyh.novelservice.user.exception.UserNotFound;
@@ -79,7 +78,7 @@ public class NovelService {
         if (isCompleted) {
             boolean hasCommonEpisodes = episodeQueryRepository.episodeExistsByNovelIdAndEpisodeType(novel.getId(), EpisodeType.COMMON);
             if (!hasCommonEpisodes) { // 일반 회차가 한개라도 존재하지 않는다면 완결로 변경 불가
-                throw new NovelHasNoEpisodes();
+                throw new NovelHasNoCommonEpisodes();
             }
         }
 


### PR DESCRIPTION
## 🔖 연관된 이슈
- #86 
## 🧾 작업 내용
- 소설을 완결로 변경 시 일반 회차가 한개라도 존재해야 가능하도록 수정
- EpisodeQueryRepository 의 프롤로그 존재 여부 쿼리 메서드를 리펙토링 해 조건으로 쓸 회차 종류를 동적으로 결정할 수 있도록 개선
