### PR TITLE
Refactoring: Service 클래스 내부의 검증 로직 분리

### DIFF
--- a/novelservice/src/main/java/com/iucyh/novelservice/episode/service/EpisodeService.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/episode/service/EpisodeService.java
@@ -1,30 +1,25 @@
 package com.iucyh.novelservice.episode.service;
 
 import com.iucyh.novelservice.common.exception.DataNotFound;
-import com.iucyh.novelservice.common.vo.HtmlContent;
-import com.iucyh.novelservice.episode.enumtype.EpisodeType;
-import com.iucyh.novelservice.episode.exception.EpisodeContentLengthNotValid;
 import com.iucyh.novelservice.episode.repository.query.EpisodeQueryRepository;
 import com.iucyh.novelservice.episode.service.dto.command.CreateEpisodeCommand;
 import com.iucyh.novelservice.episode.service.dto.command.DeleteEpisodeCommand;
 import com.iucyh.novelservice.episode.service.dto.command.UpdateEpisodeCommand;
 import com.iucyh.novelservice.episode.service.dto.command.UpdateEpisodeContentCommand;
 import com.iucyh.novelservice.episode.service.dto.mapper.EpisodeCommandMapper;
+import com.iucyh.novelservice.episode.service.policy.EpisodePolicyValidator;
 import com.iucyh.novelservice.episode.web.dto.response.EpisodeSaveResponse;
-import com.iucyh.novelservice.novel.exception.NovelAlreadyCompleted;
-import com.iucyh.novelservice.novel.exception.NovelAlreadyHasPrologue;
 import com.iucyh.novelservice.episode.domain.Episode;
 import com.iucyh.novelservice.novel.domain.Novel;
 import com.iucyh.novelservice.episode.web.dto.mapper.EpisodeResponseMapper;
 import com.iucyh.novelservice.episode.repository.EpisodeRepository;
 import com.iucyh.novelservice.novel.repository.NovelRepository;
+import com.iucyh.novelservice.novel.service.policy.NovelPolicyValidator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
-
-import static com.iucyh.novelservice.episode.constant.EpisodeConstants.*;
 
 @Service
 @Transactional
@@ -35,13 +30,14 @@ public class EpisodeService {
     private final EpisodeQueryRepository episodeQueryRepository;
     private final EpisodeRepository episodeRepository;
 
+    private final NovelPolicyValidator novelPolicyValidator;
+    private final EpisodePolicyValidator episodePolicyValidator;
+
     public EpisodeSaveResponse createEpisode(CreateEpisodeCommand command) {
         Novel novel = findNovelWithUserId(command.userId(), command.novelPublicId());
 
-        if (novel.isCompletedNovel()) {
-            throw new NovelAlreadyCompleted(); // 완결된 소설은 회차 생성 불가
-        }
-        validateContentLength(command.episodeType(), command.content());
+        novelPolicyValidator.validateNovelNotCompleted(novel); // 완결된 소설은 회차 생성 불가
+        episodePolicyValidator.validateContentLength(command.episodeType(), command.content());
 
         return switch (command.episodeType()) {
             case COMMON -> createCommonEpisode(command, novel);
@@ -58,7 +54,7 @@ public class EpisodeService {
 
     public void updateEpisodeContent(UpdateEpisodeContentCommand command) {
         Episode episode = findEpisodeWithNovelUser(command.episodePublicId(), command.userId());
-        validateContentLength(episode.getEpisodeType(), command.content());
+        episodePolicyValidator.validateContentLength(episode.getEpisodeType(), command.content());
 
         episode.updateContent(command.content().getSanitizedValue());
     }
@@ -67,9 +63,7 @@ public class EpisodeService {
         Episode episode = findEpisodeWithNovelUserFetch(command.episodePublicId(), command.userId());
         Novel novel = episode.getNovel();
 
-        if (novel.isCompletedNovel()) {
-            throw new NovelAlreadyCompleted(); // 완결된 소설은 회차 삭제 불가
-        }
+        novelPolicyValidator.validateNovelNotCompleted(novel); // 완결된 소설은 회차 삭제 불가
 
         episode.softDelete();
         // 삭제될 회차와 삭제된 회차를 제외하고 나머지 회차들 중 가장 최신 회차의 등록일로 Novel의 lastEpisodeAt 업데이트
@@ -89,44 +83,12 @@ public class EpisodeService {
     }
 
     private EpisodeSaveResponse createPrologueEpisode(CreateEpisodeCommand command, Novel novel) {
-        boolean prologueExists = episodeQueryRepository.episodeExistsByNovelIdAndEpisodeType(novel.getId(), EpisodeType.PROLOGUE);
-        if (prologueExists) { // 프롤로그는 소설 당 1개만 존재가능
-            throw new NovelAlreadyHasPrologue();
-        }
+        novelPolicyValidator.validateNovelHasNoPrologueEpisode(novel.getId()); // 프롤로그는 소설 당 1개만 존재가능
 
         Episode episode = EpisodeCommandMapper.toEpisode(command, novel, 0);
         Episode savedEpisode = episodeRepository.save(episode);
 
         return EpisodeResponseMapper.toEpisodeSaveResponse(savedEpisode);
-    }
-
-    /**
-     * <p>본문의 길이를 episodeType에 따라 검증</p>
-     * @param episodeType 검증의 기준으로 사용할 {@code EpisodeType}
-     * @param content 검증할 본문
-     * @throws EpisodeContentLengthNotValid 본문의 길이가 너무 길거나 짧을 때
-     */
-    private void validateContentLength(EpisodeType episodeType, HtmlContent content) {
-        int min = 0;
-        int max = 0;
-
-        switch (episodeType) {
-            case COMMON -> {
-                min = COMMON_EPISODE_CONTENT_LENGTH_MIN;
-                max = COMMON_EPISODE_CONTENT_LENGTH_MAX;
-            }
-
-            case PROLOGUE -> {
-                min = PROLOGUE_EPISODE_CONTENT_LENGTH_MIN;
-                max = PROLOGUE_EPISODE_CONTENT_LENGTH_MAX;
-            }
-        }
-
-        String textValue = content.getTextValue();
-        boolean isValid = textValue.length() >= min && textValue.length() <= max;
-        if (!isValid) {
-            throw new EpisodeContentLengthNotValid(episodeType, min, max);
-        }
     }
 
     private Novel findNovelWithUserId(long userId, String novelPublicId) {

--- a/novelservice/src/main/java/com/iucyh/novelservice/episode/service/policy/EpisodePolicyValidator.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/episode/service/policy/EpisodePolicyValidator.java
@@ -1,0 +1,42 @@
+package com.iucyh.novelservice.episode.service.policy;
+
+import com.iucyh.novelservice.common.vo.HtmlContent;
+import com.iucyh.novelservice.episode.enumtype.EpisodeType;
+import com.iucyh.novelservice.episode.exception.EpisodeContentLengthNotValid;
+import org.springframework.stereotype.Component;
+
+import static com.iucyh.novelservice.episode.constant.EpisodeConstants.*;
+import static com.iucyh.novelservice.episode.constant.EpisodeConstants.PROLOGUE_EPISODE_CONTENT_LENGTH_MAX;
+
+@Component
+public class EpisodePolicyValidator {
+
+    /**
+     * <p>회차의 본문 길이가 유효한지 {@code EpisodeType}에 맞는 기준으로 검증</p>
+     * @param episodeType 검사할 본문을 가지고 있는 회차의 {@code EpisodeType}
+     * @param content 검사할 본문
+     * @throws EpisodeContentLengthNotValid 회차의 길이가 유효하지 않을때(너무 짧거나, 너무 길때)
+     */
+    public void validateContentLength(EpisodeType episodeType, HtmlContent content) throws EpisodeContentLengthNotValid {
+        int min = 0;
+        int max = 0;
+
+        switch (episodeType) {
+            case COMMON -> {
+                min = COMMON_EPISODE_CONTENT_LENGTH_MIN;
+                max = COMMON_EPISODE_CONTENT_LENGTH_MAX;
+            }
+
+            case PROLOGUE -> {
+                min = PROLOGUE_EPISODE_CONTENT_LENGTH_MIN;
+                max = PROLOGUE_EPISODE_CONTENT_LENGTH_MAX;
+            }
+        }
+
+        String textValue = content.getTextValue();
+        boolean isValid = textValue.length() >= min && textValue.length() <= max;
+        if (!isValid) {
+            throw new EpisodeContentLengthNotValid(episodeType, min, max);
+        }
+    }
+}

--- a/novelservice/src/main/java/com/iucyh/novelservice/episode/service/policy/EpisodePolicyValidator.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/episode/service/policy/EpisodePolicyValidator.java
@@ -34,7 +34,7 @@ public class EpisodePolicyValidator {
         }
 
         String textValue = content.getTextValue();
-        boolean isValid = textValue.length() >= min && textValue.length() <= max;
+        boolean isValid = min <= textValue.length() && textValue.length() <= max;
         if (!isValid) {
             throw new EpisodeContentLengthNotValid(episodeType, min, max);
         }

--- a/novelservice/src/main/java/com/iucyh/novelservice/novel/repository/query/NovelQueryRepository.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/novel/repository/query/NovelQueryRepository.java
@@ -21,6 +21,16 @@ public interface NovelQueryRepository {
     boolean existsByPublicId(String publicId);
 
     /**
+     * <p>{@code userId}에 해당하는 유저가 작성한 소설 중 전달된 {@code title}과 중복되는 제목이 있는지 검사</p>
+     * <b>삭제된 소설은 제외하고 검사, 만약 {@code publicId}가 null이 아니라면 그에 해당하는 소설도 제외하고 검사(업데이트 중인 소설을 제외하는 등의 상황에서 사용)</b>
+     * @param title 검사할 제목
+     * @param userId 기준이 될 유저의 pk
+     * @param publicId 추가로 제외할 소설의 public id (선택, 모든 소설을 대상으로 검사 시 null 전달)
+     * @return 중복되는 제목을 가진 소설이 존재하면 {@code true}, 아니라면 {@code false}
+     */
+    boolean novelTitleExistsByUserId(String title, Long userId, String publicId);
+
+    /**
      * @param category 필터링 할 카테고리, 모든 카테고리 조회 시 null 전달
      */
     List<Novel> findNovels(NovelPagingCondition condition, NovelPagingStrategy strategy, NovelCategory category);

--- a/novelservice/src/main/java/com/iucyh/novelservice/novel/repository/query/NovelQueryRepositoryImpl.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/novel/repository/query/NovelQueryRepositoryImpl.java
@@ -36,6 +36,21 @@ public class NovelQueryRepositoryImpl implements NovelQueryRepository {
     }
 
     @Override
+    public boolean novelTitleExistsByUserId(String title, Long userId, String publicId) {
+        Integer result = queryFactory
+                .selectOne()
+                .from(novel)
+                .where(
+                        novel.title.eq(title),
+                        novel.user.id.eq(userId),
+                        publicId == null ? null : novel.publicId.ne(publicId),
+                        novel.deletedAt.isNull()
+                )
+                .fetchFirst();
+        return result != null;
+    }
+
+    @Override
     public List<Novel> findNovels(NovelPagingCondition condition, NovelPagingStrategy strategy, NovelCategory category) {
         JPAQuery<Novel> query = queryFactory
                 .selectFrom(novel)

--- a/novelservice/src/main/java/com/iucyh/novelservice/novel/service/NovelService.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/novel/service/NovelService.java
@@ -67,7 +67,7 @@ public class NovelService {
 
         boolean isCompleted = command.isCompleted();
         if (isCompleted) {
-            // 일반 회차가 한개라도 존재하지 않는다면 완결로 변경 불가
+            // 일반 회차가 한개도 존재하지 않는다면 완결로 변경 불가
             novelPolicyValidator.validateNovelHasCommonEpisodes(novel.getId());
         }
 

--- a/novelservice/src/main/java/com/iucyh/novelservice/novel/service/NovelService.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/novel/service/NovelService.java
@@ -1,17 +1,14 @@
 package com.iucyh.novelservice.novel.service;
 
 import com.iucyh.novelservice.common.exception.DataNotFound;
-import com.iucyh.novelservice.episode.enumtype.EpisodeType;
 import com.iucyh.novelservice.episode.repository.EpisodeRepository;
-import com.iucyh.novelservice.episode.repository.query.EpisodeQueryRepository;
-import com.iucyh.novelservice.novel.exception.DuplicateNovelTitle;
-import com.iucyh.novelservice.novel.exception.NovelHasNoCommonEpisodes;
 import com.iucyh.novelservice.novel.domain.Novel;
 import com.iucyh.novelservice.novel.service.dto.command.CreateNovelCommand;
 import com.iucyh.novelservice.novel.service.dto.command.DeleteNovelCommand;
 import com.iucyh.novelservice.novel.service.dto.command.UpdateNovelCommand;
 import com.iucyh.novelservice.novel.service.dto.command.UpdateNovelCompletionCommand;
 import com.iucyh.novelservice.novel.service.dto.mapper.NovelCommandMapper;
+import com.iucyh.novelservice.novel.service.policy.NovelPolicyValidator;
 import com.iucyh.novelservice.novel.web.dto.mapper.NovelResponseMapper;
 import com.iucyh.novelservice.novel.web.dto.response.NovelCompletionResponse;
 import com.iucyh.novelservice.novel.web.dto.response.NovelLikeCountResponse;
@@ -31,17 +28,15 @@ public class NovelService {
     private final UserRepository userRepository;
     private final NovelRepository novelRepository;
     private final EpisodeRepository episodeRepository;
-    private final EpisodeQueryRepository episodeQueryRepository;
+
+    private final NovelPolicyValidator novelPolicyValidator;
 
     public NovelSaveResponse createNovel(CreateNovelCommand command) {
         long userId = command.userId();
         User user = findUserById(userId);
 
-        String title = command.title();
-        boolean isDuplicateTitle = novelRepository.existsByTitleAndUserId(title, userId);
-        if (isDuplicateTitle) {
-            throw new DuplicateNovelTitle(title);
-        }
+        // 같은 작가의 소설 중 중복되는 제목이 있다면 소설 생성 불가
+        novelPolicyValidator.validateTitleNotDuplicatedInUserNovels(command.title(), userId);
 
         Novel newNovel = NovelCommandMapper.toNovel(command, user);
         Novel savedNovel = novelRepository.save(newNovel);
@@ -55,11 +50,8 @@ public class NovelService {
         Novel novel = findNovelWithUserId(userId, novelPublicId);
 
         if (command.title() != null) {
-            String title = command.title();
-            boolean isDuplicateTitle = novelRepository.existsByTitleAndUserIdAndPublicIdNot(title, userId, novelPublicId);
-            if (isDuplicateTitle) {
-                throw new DuplicateNovelTitle(title);
-            }
+            // 같은 작가의 소설 중 중복되는 제목이 있다면 소설 업데이트 불가 (업데이트 중인 소설은 제외하고 검증)
+            novelPolicyValidator.validateTitleNotDuplicatedInUserNovels(command.title(), userId, novelPublicId);
         }
 
         novel.updateTextMetaData(command.title(), command.description());
@@ -75,10 +67,8 @@ public class NovelService {
 
         boolean isCompleted = command.isCompleted();
         if (isCompleted) {
-            boolean hasCommonEpisodes = episodeQueryRepository.episodeExistsByNovelIdAndEpisodeType(novel.getId(), EpisodeType.COMMON);
-            if (!hasCommonEpisodes) { // 일반 회차가 한개라도 존재하지 않는다면 완결로 변경 불가
-                throw new NovelHasNoCommonEpisodes();
-            }
+            // 일반 회차가 한개라도 존재하지 않는다면 완결로 변경 불가
+            novelPolicyValidator.validateNovelHasCommonEpisodes(novel.getId());
         }
 
         novel.updateCompletion(isCompleted);

--- a/novelservice/src/main/java/com/iucyh/novelservice/novel/service/policy/NovelPolicyValidator.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/novel/service/policy/NovelPolicyValidator.java
@@ -19,8 +19,10 @@ public class NovelPolicyValidator {
     private final EpisodeQueryRepository episodeQueryRepository;
 
     /**
-     * <p>{@code userId}에 해당하는 유저가 작성한 소설 중 전달된 {@code title}과 중복되는 제목을 가진 소설이 없는지 검증</p>
-     * <b>삭제된 소설은 제외하고 검증</b>
+     * <p>{@code userId}에 해당하는 유저가 작성한 소설 중 전달된 {@code title}과 중복되는 제목을 가진 소설이 없는지 검증
+     * <br>
+     * 삭제된 소설은 제외하고 검증</p>
+     * <b>주의: 내부적으로 DB를 조회하므로 Transaction 안에서 실행해야 합니다.</b>
      * @param title 검증할 제목
      * @param userId 기준이 될 유저의 pk
      * @throws DuplicateNovelTitle 중복되는 제목을 가진 소설이 존재할때
@@ -33,9 +35,11 @@ public class NovelPolicyValidator {
     }
 
     /**
-     * <p>{@code userId}에 해당하는 유저가 작성한 소설 중 전달된 {@code title}과 중복되는 제목을 가진 소설이 없는지 검증</p>
-     * <p>업데이트하고 있는 소설을 제외하고 검증해야 할때 등의 상황에서 사용</p>
-     * <b>삭제된 소설과 {@code novelPublicId}에 해당하는 소설은 제외하고 검증</b>
+     * <p>{@code userId}에 해당하는 유저가 작성한 소설 중 전달된 {@code title}과 중복되는 제목을 가진 소설이 없는지 검증
+     * <br>
+     * 업데이트하고 있는 소설을 제외하고 검증해야 할때 등의 상황에서 사용</p>
+     * <p>삭제된 소설과 {@code novelPublicId}에 해당하는 소설은 제외하고 검증</p>
+     * <b>주의: 내부적으로 DB를 조회하므로 Transaction 안에서 실행해야 합니다.</b>
      * @param title 검증할 제목
      * @param userId 기준이 될 유저의 pk
      * @param novelPublicId 추가로 제외할 소설의 public id
@@ -50,6 +54,7 @@ public class NovelPolicyValidator {
 
     /**
      * <p>{@code novelId}에 해당하는 소설에 일반(COMMON) 회차가 한개라도 존재하는지 검증</p>
+     * <b>주의: 내부적으로 DB를 조회하므로 Transaction 안에서 실행해야 합니다.</b>
      * @param novelId 검증할 소설의 pk
      * @throws NovelHasNoCommonEpisodes 해당 소설에 일반 회차가 한개도 존재하지 않을때
      */
@@ -62,6 +67,7 @@ public class NovelPolicyValidator {
 
     /**
      * <p>{@code novelId}에 해당하는 소설에 프롤로그 회차가 존재하지 않는지 검증</p>
+     * <b>주의: 내부적으로 DB를 조회하므로 Transaction 안에서 실행해야 합니다.</b>
      * @param novelId 검증할 소설의 pk
      * @throws NovelAlreadyHasPrologue 해당 소설에 프롤로그 회차가 존재할때
      */

--- a/novelservice/src/main/java/com/iucyh/novelservice/novel/service/policy/NovelPolicyValidator.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/novel/service/policy/NovelPolicyValidator.java
@@ -1,0 +1,85 @@
+package com.iucyh.novelservice.novel.service.policy;
+
+import com.iucyh.novelservice.episode.enumtype.EpisodeType;
+import com.iucyh.novelservice.episode.repository.query.EpisodeQueryRepository;
+import com.iucyh.novelservice.novel.domain.Novel;
+import com.iucyh.novelservice.novel.exception.DuplicateNovelTitle;
+import com.iucyh.novelservice.novel.exception.NovelAlreadyCompleted;
+import com.iucyh.novelservice.novel.exception.NovelAlreadyHasPrologue;
+import com.iucyh.novelservice.novel.exception.NovelHasNoCommonEpisodes;
+import com.iucyh.novelservice.novel.repository.query.NovelQueryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class NovelPolicyValidator {
+
+    private final NovelQueryRepository novelQueryRepository;
+    private final EpisodeQueryRepository episodeQueryRepository;
+
+    /**
+     * <p>{@code userId}에 해당하는 유저가 작성한 소설 중 전달된 {@code title}과 중복되는 제목을 가진 소설이 없는지 검증</p>
+     * <b>삭제된 소설은 제외하고 검증</b>
+     * @param title 검증할 제목
+     * @param userId 기준이 될 유저의 pk
+     * @throws DuplicateNovelTitle 중복되는 제목을 가진 소설이 존재할때
+     */
+    public void validateTitleNotDuplicatedInUserNovels(String title, long userId) throws DuplicateNovelTitle {
+        boolean isDuplicated = novelQueryRepository.novelTitleExistsByUserId(title, userId, null);
+        if (isDuplicated) {
+            throw new DuplicateNovelTitle(title);
+        }
+    }
+
+    /**
+     * <p>{@code userId}에 해당하는 유저가 작성한 소설 중 전달된 {@code title}과 중복되는 제목을 가진 소설이 없는지 검증</p>
+     * <p>업데이트하고 있는 소설을 제외하고 검증해야 할때 등의 상황에서 사용</p>
+     * <b>삭제된 소설과 {@code novelPublicId}에 해당하는 소설은 제외하고 검증</b>
+     * @param title 검증할 제목
+     * @param userId 기준이 될 유저의 pk
+     * @param novelPublicId 추가로 제외할 소설의 public id
+     * @throws DuplicateNovelTitle 중복되는 제목을 가진 소설이 존재할때
+     */
+    public void validateTitleNotDuplicatedInUserNovels(String title, long userId, String novelPublicId) throws DuplicateNovelTitle {
+        boolean isDuplicated = novelQueryRepository.novelTitleExistsByUserId(title, userId, novelPublicId);
+        if (isDuplicated) {
+            throw new DuplicateNovelTitle(title);
+        }
+    }
+
+    /**
+     * <p>{@code novelId}에 해당하는 소설에 일반(COMMON) 회차가 한개라도 존재하는지 검증</p>
+     * @param novelId 검증할 소설의 pk
+     * @throws NovelHasNoCommonEpisodes 해당 소설에 일반 회차가 한개도 존재하지 않을때
+     */
+    public void validateNovelHasCommonEpisodes(long novelId) throws NovelHasNoCommonEpisodes {
+        boolean hasCommonEpisode = episodeQueryRepository.episodeExistsByNovelIdAndEpisodeType(novelId, EpisodeType.COMMON);
+        if (!hasCommonEpisode) {
+            throw new NovelHasNoCommonEpisodes();
+        }
+    }
+
+    /**
+     * <p>{@code novelId}에 해당하는 소설에 프롤로그 회차가 존재하지 않는지 검증</p>
+     * @param novelId 검증할 소설의 pk
+     * @throws NovelAlreadyHasPrologue 해당 소설에 프롤로그 회차가 존재할때
+     */
+    public void validateNovelHasNoPrologueEpisode(long novelId) throws NovelAlreadyHasPrologue {
+        boolean hasPrologueEpisode = episodeQueryRepository.episodeExistsByNovelIdAndEpisodeType(novelId, EpisodeType.PROLOGUE);
+        if (hasPrologueEpisode) {
+            throw new NovelAlreadyHasPrologue();
+        }
+    }
+
+    /**
+     * <p>소설이 완결되지 않았는지 검증</p>
+     * @param novel 검증할 소설의 엔티티
+     * @throws NovelAlreadyCompleted 소설이 완결되었을 때
+     */
+    public void validateNovelNotCompleted(Novel novel) throws NovelAlreadyCompleted {
+        if (novel.isCompletedNovel()) {
+            throw new NovelAlreadyCompleted();
+        }
+    }
+}

--- a/novelservice/src/main/java/com/iucyh/novelservice/novel/service/policy/NovelPolicyValidator.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/novel/service/policy/NovelPolicyValidator.java
@@ -19,9 +19,8 @@ public class NovelPolicyValidator {
     private final EpisodeQueryRepository episodeQueryRepository;
 
     /**
-     * <p>{@code userId}에 해당하는 유저가 작성한 소설 중 전달된 {@code title}과 중복되는 제목을 가진 소설이 없는지 검증
-     * <br>
-     * 삭제된 소설은 제외하고 검증</p>
+     * <p>{@code userId}에 해당하는 유저가 작성한 소설 중 전달된 {@code title}과 중복되는 제목을 가진 소설이 없는지 검증</p>
+     * <p>삭제된 소설은 제외하고 검증</p>
      * <b>주의: 내부적으로 DB를 조회하므로 Transaction 안에서 실행해야 합니다.</b>
      * @param title 검증할 제목
      * @param userId 기준이 될 유저의 pk


### PR DESCRIPTION
## 🔖 연관된 이슈
- #92 
## 🧾 작업 내용
- 각 도메인별 PolicyValidator 를 구현하여 각 도메인의 정책 검증 로직을 캡슐화
- 자주 변경되는 검증 로직과 비교적 안정적인 유즈케이스 로직을 클래스 단위로 분리해 유지보수성 및 확장성 증가
