### PR TITLE
Chore: DB 테이블별 PK 컬럼명 변경

### DIFF
--- a/novelservice/docker/db/mysql/init/100-schema.sql
+++ b/novelservice/docker/db/mysql/init/100-schema.sql
@@ -3,7 +3,7 @@ USE `novel_service`;
 DROP TABLE IF EXISTS `user`;
 CREATE TABLE `user`
 (
-    id         BIGINT AUTO_INCREMENT PRIMARY KEY,
+    user_id    BIGINT AUTO_INCREMENT PRIMARY KEY,
     public_id  VARCHAR(25)  NOT NULL UNIQUE,
     email      VARCHAR(320) NOT NULL UNIQUE,
     password   VARCHAR(255) NOT NULL,
@@ -33,7 +33,7 @@ CREATE TABLE `novel`
     updated_at          DATETIME     NOT NULL DEFAULT NOW(),
     deleted_at          DATETIME NULL,
 
-    CONSTRAINT fk_novel_user FOREIGN KEY (user_id) REFERENCES user (id),
+    CONSTRAINT fk_novel_user FOREIGN KEY (user_id) REFERENCES user (user_id),
     UNIQUE KEY uq_user_title (user_id, title)
 );
 
@@ -65,7 +65,7 @@ CREATE TABLE `novel_like`
     novel_id      BIGINT   NOT NULL,
     created_at    DATETIME NOT NULL DEFAULT NOW(),
 
-    CONSTRAINT fk_novel_like_user FOREIGN KEY (user_id) REFERENCES user (id),
+    CONSTRAINT fk_novel_like_user FOREIGN KEY (user_id) REFERENCES user (user_id),
     CONSTRAINT fk_novel_like_novel FOREIGN KEY (novel_id) REFERENCES novel (novel_id),
     UNIQUE KEY uq_user_novel (user_id, novel_id)
 );

--- a/novelservice/docker/db/mysql/init/100-schema.sql
+++ b/novelservice/docker/db/mysql/init/100-schema.sql
@@ -17,7 +17,7 @@ CREATE TABLE `user`
 DROP TABLE IF EXISTS `novel`;
 CREATE TABLE `novel`
 (
-    id                  BIGINT AUTO_INCREMENT PRIMARY KEY,
+    novel_id            BIGINT AUTO_INCREMENT PRIMARY KEY,
     user_id             BIGINT       NOT NULL,
     public_id           VARCHAR(25)  NOT NULL UNIQUE,
     title               VARCHAR(55)  NOT NULL,
@@ -53,46 +53,46 @@ CREATE TABLE `episode`
     updated_at     DATETIME    NOT NULL DEFAULT NOW(),
     deleted_at     DATETIME NULL,
 
-    CONSTRAINT fk_episode_novel FOREIGN KEY (novel_id) REFERENCES novel (id),
+    CONSTRAINT fk_episode_novel FOREIGN KEY (novel_id) REFERENCES novel (novel_id),
     UNIQUE KEY uq_novel_episode_number (novel_id, episode_number)
 );
 
 DROP TABLE IF EXISTS `novel_like`;
 CREATE TABLE `novel_like`
 (
-    id         BIGINT AUTO_INCREMENT PRIMARY KEY,
-    user_id    BIGINT   NOT NULL,
-    novel_id   BIGINT   NOT NULL,
-    created_at DATETIME NOT NULL DEFAULT NOW(),
+    novel_like_id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    user_id       BIGINT   NOT NULL,
+    novel_id      BIGINT   NOT NULL,
+    created_at    DATETIME NOT NULL DEFAULT NOW(),
 
     CONSTRAINT fk_novel_like_user FOREIGN KEY (user_id) REFERENCES user (id),
-    CONSTRAINT fk_novel_like_novel FOREIGN KEY (novel_id) REFERENCES novel (id),
+    CONSTRAINT fk_novel_like_novel FOREIGN KEY (novel_id) REFERENCES novel (novel_id),
     UNIQUE KEY uq_user_novel (user_id, novel_id)
 );
 
 DROP TABLE IF EXISTS `novel_daily_stats`;
 CREATE TABLE `novel_daily_stats`
 (
-    id         BIGINT AUTO_INCREMENT PRIMARY KEY,
-    novel_id   BIGINT NOT NULL,
-    stat_date  DATE   NOT NULL,
-    view_count INT    NOT NULL DEFAULT 0,
+    novel_daily_stat_id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    novel_id            BIGINT NOT NULL,
+    stat_date           DATE   NOT NULL,
+    view_count          INT    NOT NULL DEFAULT 0,
 
-    CONSTRAINT fk_novel_daily_stat_novel FOREIGN KEY (novel_id) REFERENCES novel (id),
+    CONSTRAINT fk_novel_daily_stat_novel FOREIGN KEY (novel_id) REFERENCES novel (novel_id),
     UNIQUE KEY uq_novel_stat_date (novel_id, stat_date)
 );
 
 DROP TABLE IF EXISTS `novel_period_stats`;
 CREATE TABLE `novel_period_stats`
 (
-    id          BIGINT AUTO_INCREMENT PRIMARY KEY,
-    novel_id    BIGINT      NOT NULL,
-    period_type VARCHAR(50) NOT NULL,
-    start_date  DATE        NOT NULL,
-    end_date    DATE        NOT NULL,
-    view_count  INT         NOT NULL DEFAULT 0,
-    updated_at  DATETIME    NOT NULL DEFAULT NOW(),
+    novel_period_stat_id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    novel_id             BIGINT      NOT NULL,
+    period_type          VARCHAR(50) NOT NULL,
+    start_date           DATE        NOT NULL,
+    end_date             DATE        NOT NULL,
+    view_count           INT         NOT NULL DEFAULT 0,
+    updated_at           DATETIME    NOT NULL DEFAULT NOW(),
 
-    CONSTRAINT fk_novel_period_stat_novel FOREIGN KEY (novel_id) REFERENCES novel (id),
+    CONSTRAINT fk_novel_period_stat_novel FOREIGN KEY (novel_id) REFERENCES novel (novel_id),
     UNIQUE KEY uq_novel_start_end (novel_id, period_type, start_date, end_date)
 );

--- a/novelservice/docker/db/mysql/init/100-schema.sql
+++ b/novelservice/docker/db/mysql/init/100-schema.sql
@@ -40,7 +40,7 @@ CREATE TABLE `novel`
 DROP TABLE IF EXISTS `episode`;
 CREATE TABLE `episode`
 (
-    id             BIGINT AUTO_INCREMENT PRIMARY KEY,
+    episode_id     BIGINT AUTO_INCREMENT PRIMARY KEY,
     novel_id       BIGINT      NOT NULL,
     public_id      VARCHAR(25) NOT NULL UNIQUE,
     episode_type   VARCHAR(50) NOT NULL,

--- a/novelservice/src/main/java/com/iucyh/novelservice/episode/domain/Episode.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/episode/domain/Episode.java
@@ -18,6 +18,7 @@ public class Episode extends PublicEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "episode_id")
     private Long id;
 
     @Column(length = 50, nullable = false)

--- a/novelservice/src/main/java/com/iucyh/novelservice/novel/domain/Novel.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/novel/domain/Novel.java
@@ -20,6 +20,7 @@ public class Novel extends PublicEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "novel_id")
     private Long id;
 
     @Column(length = NOVEL_TITLE_LENGTH_MAX, nullable = false)

--- a/novelservice/src/main/java/com/iucyh/novelservice/novel/domain/NovelDailyStat.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/novel/domain/NovelDailyStat.java
@@ -15,6 +15,7 @@ public class NovelDailyStat {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "novel_daily_stat_id")
     private Long id;
 
     @Column(nullable = false, updatable = false)

--- a/novelservice/src/main/java/com/iucyh/novelservice/novel/domain/NovelLike.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/novel/domain/NovelLike.java
@@ -19,6 +19,7 @@ public class NovelLike {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "novel_like_id")
     private Long id;
 
     @CreatedDate

--- a/novelservice/src/main/java/com/iucyh/novelservice/novel/domain/NovelPeriodStat.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/novel/domain/NovelPeriodStat.java
@@ -21,6 +21,7 @@ public class NovelPeriodStat {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "novel_period_stat_id")
     private Long id;
 
     @Column(length = 50, nullable = false)

--- a/novelservice/src/main/java/com/iucyh/novelservice/user/domain/User.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/user/domain/User.java
@@ -14,6 +14,7 @@ public class User extends PublicEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_id")
     private Long id;
 
     @Column(length = 320, nullable = false, unique = true)


### PR DESCRIPTION
## 🔖 연관된 이슈
- #108 
## 🧾 작업 내용
- 각 테이블의 PK를 {테이블명}_id 로 이름 변경


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **Refactor**
  * 데이터베이스 기본 키 명명 규칙을 표준화하여 코드 일관성을 개선했습니다.
  * 관련 외래 키 참조를 업데이트하여 데이터베이스 무결성을 강화했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->