### PR TITLE
Refactor: Novel lastEpisodeAt 컬럼명 변경 및 관련 코드 수정

### DIFF
--- a/novelservice/docker/db/mysql/init/100-schema.sql
+++ b/novelservice/docker/db/mysql/init/100-schema.sql
@@ -27,7 +27,7 @@ CREATE TABLE `novel`
     total_view_count    INT          NOT NULL DEFAULT 0,
     period_view_count   INT          NOT NULL DEFAULT 0,
     last_episode_number INT          NOT NULL DEFAULT 0,
-    last_episode_at     DATETIME NULL,
+    last_published_at   DATETIME NULL,
     is_completed        BOOLEAN      NOT NULL DEFAULT FALSE,
     created_at          DATETIME     NOT NULL DEFAULT NOW(),
     updated_at          DATETIME     NOT NULL DEFAULT NOW(),

--- a/novelservice/src/main/java/com/iucyh/novelservice/episode/service/EpisodeService.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/episode/service/EpisodeService.java
@@ -78,7 +78,10 @@ public class EpisodeService {
 
         Episode episode = EpisodeCommandMapper.toEpisode(command, novel, newEpisodeNumber);
         Episode savedEpisode = episodeRepository.save(episode);
-        novel.updateLastEpisode(savedEpisode.getEpisodeNumber(), savedEpisode.getCreatedAt()); // 소설의 마지막 회차와 관련된 컬럼들의 정합성을 위해 최신 회차 기준으로 업데이트
+
+        // 소설의 마지막 회차와 관련된 컬럼들의 정합성을 위해 최신 회차 기준으로 업데이트
+        novel.updateLastEpisodeNumber(savedEpisode.getEpisodeNumber());
+        novel.updateLastPublishedAt(savedEpisode.getCreatedAt());
 
         return EpisodeResponseMapper.toEpisodeSaveResponse(savedEpisode);
     }

--- a/novelservice/src/main/java/com/iucyh/novelservice/episode/service/EpisodeService.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/episode/service/EpisodeService.java
@@ -67,10 +67,10 @@ public class EpisodeService {
         novelPolicyValidator.validateNovelNotCompleted(novel); // 완결된 소설은 회차 삭제 불가
 
         episode.softDelete();
-        // 삭제될 회차와 삭제된 회차를 제외하고 나머지 회차들 중 가장 최신 회차의 등록일로 Novel의 lastEpisodeAt 업데이트
-        // 다음 최신 회차가 없다면 lastEpisodeAt을 null로 설정 (소설 목록 조회 시 소설의 lastEpisodeAt이 null이라면 회차가 없는 것으로 간주)
-        LocalDateTime lastEpisodeAt = episodeQueryRepository.findLastEpisodeAtExceptDeletedEpisode(novel.getId(), episode.getPublicId());
-        novel.updateLastEpisodeAt(lastEpisodeAt);
+        // 삭제될 회차와 삭제된 회차를 제외하고 나머지 회차들 중 가장 최신 회차의 등록일로 Novel의 lastPublishedAt 업데이트
+        // 다음 최신 회차가 없다면 lastPublishedAt을 null로 설정 (소설 목록 조회 시 소설의 lastPublishedAt이 null이라면 회차가 없는 것으로 간주)
+        LocalDateTime lastPublishedAt = episodeQueryRepository.findLastEpisodeAtExceptDeletedEpisode(novel.getId(), episode.getPublicId());
+        novel.updateLastPublishedAt(lastPublishedAt);
     }
 
     private EpisodeSaveResponse createCommonEpisode(CreateEpisodeCommand command, Novel novel) {

--- a/novelservice/src/main/java/com/iucyh/novelservice/novel/domain/Novel.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/novel/domain/Novel.java
@@ -89,9 +89,8 @@ public class Novel extends PublicEntity {
         }
     }
 
-    public void updateLastEpisode(Integer lastEpisodeNumber, LocalDateTime lastPublishedAt) {
+    public void updateLastEpisodeNumber(Integer lastEpisodeNumber) {
         this.lastEpisodeNumber = lastEpisodeNumber;
-        this.lastPublishedAt = lastPublishedAt;
     }
 
     public void updateLastPublishedAt(LocalDateTime lastPublishedAt) {

--- a/novelservice/src/main/java/com/iucyh/novelservice/novel/domain/Novel.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/novel/domain/Novel.java
@@ -45,7 +45,7 @@ public class Novel extends PublicEntity {
     @Column(nullable = false)
     private Integer lastEpisodeNumber = 0;
 
-    private LocalDateTime lastEpisodeAt;
+    private LocalDateTime lastPublishedAt;
 
     @Column(nullable = false)
     private Boolean isCompleted = false;
@@ -89,12 +89,12 @@ public class Novel extends PublicEntity {
         }
     }
 
-    public void updateLastEpisode(Integer lastEpisodeNumber, LocalDateTime lastEpisodeAt) {
+    public void updateLastEpisode(Integer lastEpisodeNumber, LocalDateTime lastPublishedAt) {
         this.lastEpisodeNumber = lastEpisodeNumber;
-        this.lastEpisodeAt = lastEpisodeAt;
+        this.lastPublishedAt = lastPublishedAt;
     }
 
-    public void updateLastEpisodeAt(LocalDateTime lastEpisodeAt) {
-        this.lastEpisodeAt = lastEpisodeAt;
+    public void updateLastPublishedAt(LocalDateTime lastPublishedAt) {
+        this.lastPublishedAt = lastPublishedAt;
     }
 }

--- a/novelservice/src/main/java/com/iucyh/novelservice/novel/repository/query/NovelQueryRepositoryImpl.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/novel/repository/query/NovelQueryRepositoryImpl.java
@@ -94,7 +94,7 @@ public class NovelQueryRepositoryImpl implements NovelQueryRepository {
      */
     private BooleanExpression applyValidNovelFilter() {
         return novel.deletedAt.isNull()
-                .and(novel.lastEpisodeAt.isNotNull());
+                .and(novel.lastPublishedAt.isNotNull());
     }
 
     private BooleanExpression applyCategoryFilter(NovelCategory category) {

--- a/novelservice/src/main/java/com/iucyh/novelservice/novel/repository/query/paging/NovelLastUpdatePagingStrategy.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/novel/repository/query/paging/NovelLastUpdatePagingStrategy.java
@@ -17,7 +17,7 @@ public class NovelLastUpdatePagingStrategy extends AbstractNovelPagingStrategy {
     @Override
     protected OrderSpecifier<?>[] applyOrder() {
         return new OrderSpecifier[] {
-                novel.lastEpisodeAt.desc(),
+                novel.lastPublishedAt.desc(),
                 novel.createdAt.desc(),
                 novel.id.desc()
         };
@@ -26,15 +26,15 @@ public class NovelLastUpdatePagingStrategy extends AbstractNovelPagingStrategy {
     @Override
     protected BooleanExpression applyCursor(NovelCursor cursor) {
         NovelLastUpdateCursor lastUpdateCursor = (NovelLastUpdateCursor) cursor;
-        return novel.lastEpisodeAt.lt(lastUpdateCursor.lastEpisodeAt())
+        return novel.lastPublishedAt.lt(lastUpdateCursor.lastPublishedAt())
                 .or(
-                        novel.lastEpisodeAt.eq(lastUpdateCursor.lastEpisodeAt())
+                        novel.lastPublishedAt.eq(lastUpdateCursor.lastPublishedAt())
                                 .and(
                                         novel.createdAt.lt(lastUpdateCursor.lastCreatedAt())
                                 )
                 )
                 .or(
-                        novel.lastEpisodeAt.eq(lastUpdateCursor.lastEpisodeAt())
+                        novel.lastPublishedAt.eq(lastUpdateCursor.lastPublishedAt())
                                 .and(
                                         novel.createdAt.eq(lastUpdateCursor.lastCreatedAt())
                                 )
@@ -46,7 +46,7 @@ public class NovelLastUpdatePagingStrategy extends AbstractNovelPagingStrategy {
 
     @Override
     public NovelCursor createCursor(Novel lastResult) {
-        return new NovelLastUpdateCursor(lastResult.getId(), lastResult.getLastEpisodeAt(), lastResult.getCreatedAt());
+        return new NovelLastUpdateCursor(lastResult.getId(), lastResult.getLastPublishedAt(), lastResult.getCreatedAt());
     }
 
     @Override

--- a/novelservice/src/main/java/com/iucyh/novelservice/novel/repository/query/paging/NovelLikeCountPagingStrategy.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/novel/repository/query/paging/NovelLikeCountPagingStrategy.java
@@ -18,7 +18,7 @@ public class NovelLikeCountPagingStrategy extends AbstractNovelPagingStrategy {
     protected OrderSpecifier<?>[] applyOrder() {
         return new OrderSpecifier[] {
                 novel.likeCount.desc(),
-                novel.lastEpisodeAt.desc(),
+                novel.lastPublishedAt.desc(),
                 novel.id.desc()
         };
     }
@@ -30,13 +30,13 @@ public class NovelLikeCountPagingStrategy extends AbstractNovelPagingStrategy {
                 .or(
                         novel.likeCount.eq(likeCountCursor.lastLikeCount())
                                 .and(
-                                        novel.lastEpisodeAt.lt(likeCountCursor.lastEpisodeAt())
+                                        novel.lastPublishedAt.lt(likeCountCursor.lastPublishedAt())
                                 )
                 )
                 .or(
                         novel.likeCount.eq(likeCountCursor.lastLikeCount())
                                 .and(
-                                        novel.lastEpisodeAt.eq(likeCountCursor.lastEpisodeAt())
+                                        novel.lastPublishedAt.eq(likeCountCursor.lastPublishedAt())
                                 )
                                 .and(
                                         novel.id.lt(likeCountCursor.lastNovelId())
@@ -46,7 +46,7 @@ public class NovelLikeCountPagingStrategy extends AbstractNovelPagingStrategy {
 
     @Override
     public NovelCursor createCursor(Novel lastResult) {
-        return new NovelLikeCountCursor(lastResult.getId(), lastResult.getLikeCount(), lastResult.getLastEpisodeAt());
+        return new NovelLikeCountCursor(lastResult.getId(), lastResult.getLikeCount(), lastResult.getLastPublishedAt());
     }
 
     @Override

--- a/novelservice/src/main/java/com/iucyh/novelservice/novel/repository/query/paging/NovelViewCountPagingStrategy.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/novel/repository/query/paging/NovelViewCountPagingStrategy.java
@@ -18,7 +18,7 @@ public class NovelViewCountPagingStrategy extends AbstractNovelPagingStrategy {
     protected OrderSpecifier<?>[] applyOrder() {
         return new OrderSpecifier[] {
                 novel.totalViewCount.desc(),
-                novel.lastEpisodeAt.desc(),
+                novel.lastPublishedAt.desc(),
                 novel.id.desc()
         };
     }
@@ -30,13 +30,13 @@ public class NovelViewCountPagingStrategy extends AbstractNovelPagingStrategy {
                 .or(
                         novel.totalViewCount.eq(viewCountCursor.lastTotalViewCount())
                                 .and(
-                                        novel.lastEpisodeAt.lt(viewCountCursor.lastEpisodeAt())
+                                        novel.lastPublishedAt.lt(viewCountCursor.lastPublishedAt())
                                 )
                 )
                 .or(
                         novel.totalViewCount.eq(viewCountCursor.lastTotalViewCount())
                                 .and(
-                                        novel.lastEpisodeAt.eq(viewCountCursor.lastEpisodeAt())
+                                        novel.lastPublishedAt.eq(viewCountCursor.lastPublishedAt())
                                 )
                                 .and(
                                         novel.id.lt(viewCountCursor.lastNovelId())
@@ -46,7 +46,7 @@ public class NovelViewCountPagingStrategy extends AbstractNovelPagingStrategy {
 
     @Override
     public NovelCursor createCursor(Novel lastResult) {
-        return new NovelViewCountCursor(lastResult.getId(), lastResult.getTotalViewCount(), lastResult.getLastEpisodeAt());
+        return new NovelViewCountCursor(lastResult.getId(), lastResult.getTotalViewCount(), lastResult.getLastPublishedAt());
     }
 
     @Override

--- a/novelservice/src/main/java/com/iucyh/novelservice/novel/repository/query/paging/cursor/NovelLastUpdateCursor.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/novel/repository/query/paging/cursor/NovelLastUpdateCursor.java
@@ -5,6 +5,6 @@ import java.time.LocalDateTime;
 public record NovelLastUpdateCursor(
 
         long lastNovelId,
-        LocalDateTime lastEpisodeAt,
+        LocalDateTime lastPublishedAt,
         LocalDateTime lastCreatedAt
 ) implements NovelCursor {}

--- a/novelservice/src/main/java/com/iucyh/novelservice/novel/repository/query/paging/cursor/NovelLikeCountCursor.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/novel/repository/query/paging/cursor/NovelLikeCountCursor.java
@@ -6,5 +6,5 @@ public record NovelLikeCountCursor(
 
         long lastNovelId,
         int lastLikeCount,
-        LocalDateTime lastEpisodeAt
+        LocalDateTime lastPublishedAt
 ) implements NovelCursor {}

--- a/novelservice/src/main/java/com/iucyh/novelservice/novel/repository/query/paging/cursor/NovelViewCountCursor.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/novel/repository/query/paging/cursor/NovelViewCountCursor.java
@@ -6,5 +6,5 @@ public record NovelViewCountCursor(
 
         long lastNovelId,
         int lastTotalViewCount,
-        LocalDateTime lastEpisodeAt
+        LocalDateTime lastPublishedAt
 ) implements NovelCursor {}


### PR DESCRIPTION
## 🔖 연관된 이슈
- #110 
## 🧾 작업 내용
- Novel 의 엔티티, 테이블에서 lastEpisodeAt -> lastPublishedAt 으로 컬럼명 변경
- Novel의 updateLastEpisode 메서드를 updateLastEpisodeNumber 로 변경해 lastEpisodeNumber, lastPublishedAt 업데이트를 두 개의 메서드로 분리


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 소설 업데이트 추적 방식 개선: 에피소드 번호와 발행 날짜 업데이트를 분리했습니다.
  * 소설 정렬 및 필터링 기준을 "최근 발행일"로 통합했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->