### PR TITLE
Feature: 소설 목록 조회 일반 회차 존재 여부 필터링 조건 변경

### DIFF
--- a/novelservice/docker/db/mysql/init/100-schema.sql
+++ b/novelservice/docker/db/mysql/init/100-schema.sql
@@ -24,6 +24,7 @@ CREATE TABLE `novel`
     description               VARCHAR(500) NOT NULL DEFAULT '',
     category                  VARCHAR(50)  NOT NULL,
     common_episode_count      INT          NOT NULL DEFAULT 0,
+    has_common_episode        BOOLEAN      NOT NULL DEFAULT FALSE,
     like_count                INT          NOT NULL DEFAULT 0,
     total_view_count          INT          NOT NULL DEFAULT 0,
     period_view_count         INT          NOT NULL DEFAULT 0,

--- a/novelservice/src/main/java/com/iucyh/novelservice/episode/repository/query/EpisodeQueryRepository.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/episode/repository/query/EpisodeQueryRepository.java
@@ -20,6 +20,16 @@ public interface EpisodeQueryRepository {
     boolean episodeExistsByNovelIdAndEpisodeType(Long novelId, EpisodeType episodeType);
 
     /**
+     * <p>{@code novelId}에 해당하는 소설에 종류가 {@code episodeType}인 회차가 존재하는지 검사</p>
+     * <p>전달된 {@code id}에 해당하는 회차와 삭제된 회차를 제외하고 나머지를 대상으로 검사</p>
+     * @param novelId 검사할 소설의 id
+     * @param episodeType 검사할 회차 종류
+     * @param id 추가로 제외할 회차의 pk
+     * @return 조건이 맞는 회차가 존재하면 {@code true}, 아니라면 {@code false}
+     */
+    boolean episodeExistsByNovelIdAndEpisodeType(Long novelId, EpisodeType episodeType, Long id);
+
+    /**
      * <p>{@code publicId}에 해당하는 회차와 삭제된 회차를 제외한 나머지 회차 중 가장 최신 회차의 생성일 조회</p>
      * <p>제외할 회차가 없다면 publicId에 null 전달</p>
      * @param novelId 조회할 회차들이 속한 소설의 id

--- a/novelservice/src/main/java/com/iucyh/novelservice/episode/repository/query/EpisodeQueryRepositoryImpl.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/episode/repository/query/EpisodeQueryRepositoryImpl.java
@@ -44,6 +44,21 @@ public class EpisodeQueryRepositoryImpl implements EpisodeQueryRepository {
     }
 
     @Override
+    public boolean episodeExistsByNovelIdAndEpisodeType(Long novelId, EpisodeType episodeType, Long id) {
+        Integer result = queryFactory
+                .selectOne()
+                .from(episode)
+                .where(
+                        episode.novel.id.eq(novelId),
+                        episode.episodeType.eq(episodeType),
+                        episode.id.ne(id),
+                        episode.deletedAt.isNull()
+                )
+                .fetchFirst();
+        return result != null;
+    }
+
+    @Override
     public LocalDateTime findLastEpisodeAtExceptDeletedEpisode(Long novelId, String publicId) {
         return queryFactory
                 .select(episode.createdAt)

--- a/novelservice/src/main/java/com/iucyh/novelservice/episode/service/EpisodeService.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/episode/service/EpisodeService.java
@@ -1,6 +1,7 @@
 package com.iucyh.novelservice.episode.service;
 
 import com.iucyh.novelservice.common.exception.DataNotFound;
+import com.iucyh.novelservice.episode.enumtype.EpisodeType;
 import com.iucyh.novelservice.episode.repository.query.EpisodeQueryRepository;
 import com.iucyh.novelservice.episode.service.dto.command.CreateEpisodeCommand;
 import com.iucyh.novelservice.episode.service.dto.command.DeleteEpisodeCommand;
@@ -68,6 +69,14 @@ public class EpisodeService {
         novelPolicyValidator.validateNovelNotCompleted(novel); // 완결된 소설은 회차 삭제 불가
         episode.softDelete();
 
+        // novel에 더 이상 일반 회차가 한개도 존재하지 않으면 hasCommonEpisode를 false로 변경 (회차 존재 여부 조회 시 삭제중인 회차, 삭제된 회차는 제외)
+        if (episode.getEpisodeType() == EpisodeType.COMMON) { // 삭제하려는 회차가 COMMON이 아니라면 COMMON과 관련된 상태는 변하지 않으므로 업데이트 스킵
+            boolean hasCommonEpisode = episodeQueryRepository.episodeExistsByNovelIdAndEpisodeType(novel.getId(), EpisodeType.COMMON, episode.getId());
+            if (!hasCommonEpisode) {
+                novel.updateHasCommonEpisode(false);
+            }
+        }
+
         // 가장 최신 회차의 등록일을 가장 최신 회차 발행일로 변환 후 novel에 저장 (최신 회차 등록일 조회 시 삭제중인 회차, 삭제된 회차는 제외)
         LocalDateTime lastEpisodeAt = episodeQueryRepository.findLastEpisodeAtExceptDeletedEpisode(novel.getId(), episode.getPublicId());
         LocalDate lastEpisodePublishDate = toLastEpisodePublishDate(lastEpisodeAt);
@@ -85,6 +94,7 @@ public class EpisodeService {
         LocalDate lastEpisodePublishDate = toLastEpisodePublishDate(savedEpisode.getCreatedAt());
         novel.updateMaxEpisodeNumber(savedEpisode.getEpisodeNumber());
         novel.updateLastEpisodePublishDate(lastEpisodePublishDate);
+        novel.updateHasCommonEpisode(true);
 
         return EpisodeResponseMapper.toEpisodeSaveResponse(savedEpisode);
     }

--- a/novelservice/src/main/java/com/iucyh/novelservice/novel/domain/Novel.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/novel/domain/Novel.java
@@ -91,13 +91,13 @@ public class Novel extends PublicEntity {
     }
 
     public void updateHasCommonEpisode(Boolean hasCommonEpisode) {
-        if (this.hasCommonEpisode != hasCommonEpisode) {
+        if (!this.hasCommonEpisode.equals(hasCommonEpisode)) {
             this.hasCommonEpisode = hasCommonEpisode;
         }
     }
 
     public void updateCompletion(Boolean isCompleted) {
-        if (this.isCompleted != isCompleted) {
+        if (this.isCompleted != isCompleted) { // TODO: 위 메서드처럼 equals로 변경
             this.isCompleted = isCompleted;
         }
     }

--- a/novelservice/src/main/java/com/iucyh/novelservice/novel/domain/Novel.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/novel/domain/Novel.java
@@ -52,6 +52,9 @@ public class Novel extends PublicEntity {
     private LocalDate lastEpisodePublishDate;
 
     @Column(nullable = false)
+    private Boolean hasCommonEpisode = false;
+
+    @Column(nullable = false)
     private Boolean isCompleted = false;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -84,6 +87,12 @@ public class Novel extends PublicEntity {
     public void updateCategory(NovelCategory category) {
         if (category != null) {
             this.category = category;
+        }
+    }
+
+    public void updateHasCommonEpisode(Boolean hasCommonEpisode) {
+        if (this.hasCommonEpisode != hasCommonEpisode) {
+            this.hasCommonEpisode = hasCommonEpisode;
         }
     }
 

--- a/novelservice/src/main/java/com/iucyh/novelservice/novel/repository/query/NovelQueryRepositoryImpl.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/novel/repository/query/NovelQueryRepositoryImpl.java
@@ -89,12 +89,12 @@ public class NovelQueryRepositoryImpl implements NovelQueryRepository {
      * <p>필터 조건</p>
      * <ul>
      *     <li>삭제되지 않은 소설</li>
-     *     <li>회차가 한개라도 존재하는(== 최신 회차 등록일이 null이 아닌) 소설</li>
+     *     <li>일반 회차가 한개라도 존재하는 소설</li>
      * </ul>
      */
     private BooleanExpression applyValidNovelFilter() {
         return novel.deletedAt.isNull()
-                .and(novel.lastEpisodePublishDate.isNotNull());
+                .and(novel.hasCommonEpisode.isTrue());
     }
 
     private BooleanExpression applyCategoryFilter(NovelCategory category) {


### PR DESCRIPTION
## 🔖 연관된 이슈
- #116 
## 🧾 작업 내용
- 기존 계획이었던 common_episode_count > 0 조건으로 필터링 하는것은 확인해보았을 때 커서 기반 페이징 조건과 같이 쓰게 된다면  둘 다 range 조건이기 때문에 인덱스 활용이 많이 힘들고, 데이터 분포에 따라 실행 속도 차이가 컸습니다. 그래서 has_common_episode 컬럼을 추가로 두어 equal 조건으로 필터링 할 수 있게 하여 인덱스 활용을 최대한 할 수 있도록 계획을 변경하였습니다.
- has_common_episode 컬럼 추가 및 관련 엔티티 도메인 메서드 구현
- has_common_episode 컬럼 업데이트 (회차 삭제/생성 시) 로직 구현
- 소설 목록 조회 일반 회차 존재 여부 필터링 조건 변경
## 🔍 참고자료


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 소설에 일반 에피소드 보유 여부를 추적하는 필드가 추가되어, 생성·삭제 시 소설의 상태가 자동으로 갱신됩니다.

* **개선**
  * 소설의 유효성 판단 기준이 업데이트되어, 일반 에피소드 존재 여부를 기준으로 보다 정확히 분류합니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->