### PR TITLE
Feature: 소설 상세 조회에 일반 회차 개수 필드 추가

### DIFF
--- a/novelservice/src/main/java/com/iucyh/novelservice/episode/service/EpisodeService.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/episode/service/EpisodeService.java
@@ -99,6 +99,7 @@ public class EpisodeService {
         novel.updateMaxEpisodeNumber(savedEpisode.getEpisodeNumber());
         novel.updateLastEpisodePublishDate(lastEpisodePublishDate);
         novel.updateHasCommonEpisode(true);
+        novelRepository.increaseCommonEpisodeCount(novel.getId());
 
         return EpisodeResponseMapper.toEpisodeSaveResponse(savedEpisode);
     }

--- a/novelservice/src/main/java/com/iucyh/novelservice/episode/service/EpisodeService.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/episode/service/EpisodeService.java
@@ -76,7 +76,7 @@ public class EpisodeService {
         // 소설에 더 이상 회차가 한개도 존재하지 않으면 자연스럽게 null로 설정
         novel.updateLastEpisodePublishDate(lastEpisodePublishDate);
 
-        // COMMON 회차와 관련된 컬럼 동기화 (삭제하려는 회차가 COMMON이 아니라면 COMMON과 관련된 상태는 변하지 않으므로 업데이트 스킵)
+        // COMMON 회차와 관련된 컬럼 업데이트 (삭제하려는 회차가 COMMON이 아니라면 COMMON과 관련된 상태는 변하지 않으므로 업데이트 스킵)
         if (episode.getEpisodeType() == EpisodeType.COMMON) {
             boolean hasCommonEpisode = episodeQueryRepository.episodeExistsByNovelIdAndEpisodeType(novel.getId(), EpisodeType.COMMON, episode.getId());
             if (!hasCommonEpisode) {

--- a/novelservice/src/main/java/com/iucyh/novelservice/episode/service/EpisodeService.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/episode/service/EpisodeService.java
@@ -69,20 +69,24 @@ public class EpisodeService {
         novelPolicyValidator.validateNovelNotCompleted(novel); // 완결된 소설은 회차 삭제 불가
         episode.softDelete();
 
-        // novel에 더 이상 일반 회차가 한개도 존재하지 않으면 hasCommonEpisode를 false로 변경 (회차 존재 여부 조회 시 삭제중인 회차, 삭제된 회차는 제외)
-        if (episode.getEpisodeType() == EpisodeType.COMMON) { // 삭제하려는 회차가 COMMON이 아니라면 COMMON과 관련된 상태는 변하지 않으므로 업데이트 스킵
-            boolean hasCommonEpisode = episodeQueryRepository.episodeExistsByNovelIdAndEpisodeType(novel.getId(), EpisodeType.COMMON, episode.getId());
-            if (!hasCommonEpisode) {
-                novel.updateHasCommonEpisode(false);
-            }
-        }
-
         // 가장 최신 회차의 등록일을 가장 최신 회차 발행일로 변환 후 novel에 저장 (최신 회차 등록일 조회 시 삭제중인 회차, 삭제된 회차는 제외)
         LocalDateTime lastEpisodeAt = episodeQueryRepository.findLastEpisodeAtExceptDeletedEpisode(novel.getId(), episode.getPublicId());
         LocalDate lastEpisodePublishDate = toLastEpisodePublishDate(lastEpisodeAt);
 
         // 소설에 더 이상 회차가 한개도 존재하지 않으면 자연스럽게 null로 설정
         novel.updateLastEpisodePublishDate(lastEpisodePublishDate);
+
+        // COMMON 회차와 관련된 컬럼 동기화 (삭제하려는 회차가 COMMON이 아니라면 COMMON과 관련된 상태는 변하지 않으므로 업데이트 스킵)
+        if (episode.getEpisodeType() == EpisodeType.COMMON) {
+            boolean hasCommonEpisode = episodeQueryRepository.episodeExistsByNovelIdAndEpisodeType(novel.getId(), EpisodeType.COMMON, episode.getId());
+            if (!hasCommonEpisode) {
+                // novel에 더 이상 일반 회차가 한개도 존재하지 않으면 hasCommonEpisode를 false로 변경 (회차 존재 여부 조회 시 삭제중인 회차, 삭제된 회차는 제외)
+                novel.updateHasCommonEpisode(false);
+            }
+
+            // DB 레벨에서 음수값 방지
+            novelRepository.decreaseCommonEpisodeCount(novel.getId());
+        }
     }
 
     private EpisodeSaveResponse createCommonEpisode(CreateEpisodeCommand command, Novel novel) {

--- a/novelservice/src/main/java/com/iucyh/novelservice/novel/repository/NovelRepository.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/novel/repository/NovelRepository.java
@@ -54,7 +54,7 @@ public interface NovelRepository extends JpaRepository<Novel, Long> {
     @Query("""
     update Novel n
     set n.commonEpisodeCount = n.commonEpisodeCount - 1
-    where n.id = :id
+    where n.id = :id and n.commonEpisodeCount > 0
     """)
     void decreaseCommonEpisodeCount(@Param("id") Long id);
 

--- a/novelservice/src/main/java/com/iucyh/novelservice/novel/repository/NovelRepository.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/novel/repository/NovelRepository.java
@@ -34,6 +34,30 @@ public interface NovelRepository extends JpaRepository<Novel, Long> {
     """)
     Optional<Novel> findByPublicIdFetch(@Param("publicId") String publicId);
 
+    /**
+     * <p>{@code id}에 해당하는 소설의 common_episode_count 값을 1만큼 증가</p>
+     * @param id 증가시킬 소설의 pk
+     */
+    @Modifying(clearAutomatically = true)
+    @Query("""
+    update Novel n
+    set n.commonEpisodeCount = n.commonEpisodeCount + 1
+    where n.id = :id
+    """)
+    void increaseCommonEpisodeCount(@Param("id") Long id);
+
+    /**
+     * <p>{@code id}에 해당하는 소설의 common_episode_count 값을 1만큼 감소</p>
+     * @param id 감소시킬 소설의 pk
+     */
+    @Modifying(clearAutomatically = true)
+    @Query("""
+    update Novel n
+    set n.commonEpisodeCount = n.commonEpisodeCount - 1
+    where n.id = :id
+    """)
+    void decreaseCommonEpisodeCount(@Param("id") Long id);
+
     @Modifying(clearAutomatically = true)
     @Query("update Novel n set n.totalViewCount = n.totalViewCount + 1 where n.id = :novelId and n.deletedAt is null")
     void increaseTotalViewCount(@Param("novelId") Long novelId);

--- a/novelservice/src/main/java/com/iucyh/novelservice/novel/repository/NovelRepository.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/novel/repository/NovelRepository.java
@@ -42,7 +42,7 @@ public interface NovelRepository extends JpaRepository<Novel, Long> {
     @Query("""
     update Novel n
     set n.commonEpisodeCount = n.commonEpisodeCount + 1
-    where n.id = :id
+    where n.id = :id and n.deletedAt is null
     """)
     void increaseCommonEpisodeCount(@Param("id") Long id);
 
@@ -54,7 +54,7 @@ public interface NovelRepository extends JpaRepository<Novel, Long> {
     @Query("""
     update Novel n
     set n.commonEpisodeCount = n.commonEpisodeCount - 1
-    where n.id = :id and n.commonEpisodeCount > 0
+    where n.id = :id and n.commonEpisodeCount > 0 and n.deletedAt is null
     """)
     void decreaseCommonEpisodeCount(@Param("id") Long id);
 

--- a/novelservice/src/main/java/com/iucyh/novelservice/novel/web/dto/mapper/NovelResponseMapper.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/novel/web/dto/mapper/NovelResponseMapper.java
@@ -43,6 +43,7 @@ public class NovelResponseMapper {
                 novel.getTitle(),
                 novel.getDescription(),
                 novel.getCategory(),
+                novel.getCommonEpisodeCount(),
                 novel.getLikeCount(),
                 novel.getTotalViewCount(),
                 novel.isCompletedNovel(),

--- a/novelservice/src/main/java/com/iucyh/novelservice/novel/web/dto/response/NovelDetailResponse.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/novel/web/dto/response/NovelDetailResponse.java
@@ -11,6 +11,7 @@ public record NovelDetailResponse(
         String title,
         String description,
         NovelCategory category,
+        int commonEpisodeCount,
         int likeCount,
         int totalViewCount,
         boolean isCompleted,


### PR DESCRIPTION
## 🔖 연관된 이슈
- #118 
## 🧾 작업 내용
- 회차 삭제/등록 시 commonEpisodeCount 업데이트 로직 구현
- 소설 상세 조회 Response 에 commonEpisodeCount 필드 추가
## 🔍 참고자료


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * API 응답에 일반(공통) 에피소드 수(commonEpisodeCount) 정보 추가

* **버그 수정**
  * 에피소드 생성 시 소설의 일반 에피소드 수가 데이터베이스 수준에서 정확히 증가하도록 개선
  * 에피소드 삭제 시 소설의 일반 에피소드 수와 표시 여부(hasCommonEpisode)가 데이터베이스와 일관되게 갱신되도록 개선

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->