### PR TITLE
Feture: 회차 등록 시 공통으로 최신 회차 발행일 업데이트

### DIFF
--- a/novelservice/src/main/java/com/iucyh/novelservice/episode/service/EpisodeService.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/episode/service/EpisodeService.java
@@ -42,10 +42,21 @@ public class EpisodeService {
         Novel novel = findNovelWithUserId(command.userId(), command.novelPublicId());
         novelPolicyValidator.validateNovelNotCompleted(novel); // 완결된 소설은 회차 생성 불가
 
-        return switch (command.episodeType()) {
+        Episode savedEpisode = switch (command.episodeType()) {
             case COMMON -> createCommonEpisode(command, novel);
             case PROLOGUE -> createPrologueEpisode(command, novel);
         };
+        LocalDate lastEpisodePublishDate = toLastEpisodePublishDate(savedEpisode.getCreatedAt());
+        novel.updateLastEpisodePublishDate(lastEpisodePublishDate);
+
+        // COMMON 회차 생성 시 관련 컬럼 업데이트
+        if (command.episodeType() == EpisodeType.COMMON) {
+            novel.updateMaxEpisodeNumber(savedEpisode.getEpisodeNumber());
+            novel.updateHasCommonEpisode(true);
+            novelRepository.increaseCommonEpisodeCount(novel.getId());
+        }
+
+        return EpisodeResponseMapper.toEpisodeSaveResponse(savedEpisode);
     }
 
     public EpisodeSaveResponse updateEpisode(UpdateEpisodeCommand command) {
@@ -89,29 +100,18 @@ public class EpisodeService {
         }
     }
 
-    private EpisodeSaveResponse createCommonEpisode(CreateEpisodeCommand command, Novel novel) {
+    private Episode createCommonEpisode(CreateEpisodeCommand command, Novel novel) {
         int newEpisodeNumber = novel.getMaxEpisodeNumber() + 1;
 
         Episode episode = EpisodeCommandMapper.toEpisode(command, novel, newEpisodeNumber);
-        Episode savedEpisode = episodeRepository.save(episode);
-
-        LocalDate lastEpisodePublishDate = toLastEpisodePublishDate(savedEpisode.getCreatedAt());
-        novel.updateMaxEpisodeNumber(savedEpisode.getEpisodeNumber());
-        novel.updateLastEpisodePublishDate(lastEpisodePublishDate);
-        novel.updateHasCommonEpisode(true);
-        novelRepository.increaseCommonEpisodeCount(novel.getId());
-
-        return EpisodeResponseMapper.toEpisodeSaveResponse(savedEpisode);
+        return episodeRepository.save(episode);
     }
 
-    // TODO: 프롤로그 등록 시에도 lastEpisodePublishDate 업데이트
-    private EpisodeSaveResponse createPrologueEpisode(CreateEpisodeCommand command, Novel novel) {
+    private Episode createPrologueEpisode(CreateEpisodeCommand command, Novel novel) {
         novelPolicyValidator.validateNovelHasNoPrologueEpisode(novel.getId()); // 프롤로그는 소설 당 1개만 존재가능
 
         Episode episode = EpisodeCommandMapper.toEpisode(command, novel, 0);
-        Episode savedEpisode = episodeRepository.save(episode);
-
-        return EpisodeResponseMapper.toEpisodeSaveResponse(savedEpisode);
+        return episodeRepository.save(episode);
     }
 
     /**


### PR DESCRIPTION
## 🔖 연관된 이슈
- #120 
## 🧾 작업 내용
- COMMON, PROLOGUE 상관 없이 모든 회차에 대해 최신 회차 발행일 업데이트로 변경
- createEpisode 메인 메서드에서 novel 과 관련된 상태를 통합적으로 관리하고, 각 회차 타입별 회차 생성 메서드에서는 해당 타입에 맞는 추가 검증 및 회차 생성만 담당하도록 리펙토링
## 🔍 참고자료


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 소설의 마지막 에피소드 발행 날짜가 이제 정확하게 업데이트됩니다.
  * 공개 에피소드 생성 시 소설 상태 관리가 개선되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->