### PR TITLE
Performance: hibernate 배치 설정 개선

### DIFF
--- a/novelservice/src/main/resources/application.yml
+++ b/novelservice/src/main/resources/application.yml
@@ -21,4 +21,7 @@ spring:
     properties:
       hibernate:
         jdbc:
-          batch_size: 300
+          batch_size: 100
+        order_inserts: true
+        order_updates: true
+        default_batch_fetch_size: 150


### PR DESCRIPTION
## 🔖 연관된 이슈
- #126 
## 🧾 작업 내용
- jdbc.batch_size, default_batch_fetch_size, order_inserts, order_updates 추가
- 쓰기 작업은 크게 많지 않으므로 보수적으로 jdbc.batch_size 를 100으로 설정
- 읽기 작업은 조금 더 크게 잡아 default_batch_size 를 150으로 설정
## 🔍 참고자료
- https://techblog.woowahan.com/2695


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선**
  * 데이터베이스 성능 최적화를 위한 내부 설정 조정

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->