### PR TITLE
Feature: 소설 목록 조회 좋아요순 정렬 개편

### DIFF
--- a/novelservice/src/main/java/com/iucyh/novelservice/novel/repository/query/paging/NovelLikeCountPagingStrategy.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/novel/repository/query/paging/NovelLikeCountPagingStrategy.java
@@ -18,7 +18,7 @@ public class NovelLikeCountPagingStrategy extends AbstractNovelPagingStrategy {
     protected OrderSpecifier<?>[] applyOrder() {
         return new OrderSpecifier[] {
                 novel.likeCount.desc(),
-                novel.lastEpisodePublishDate.desc(),
+                novel.totalViewCount.desc(),
                 novel.id.desc()
         };
     }
@@ -26,27 +26,27 @@ public class NovelLikeCountPagingStrategy extends AbstractNovelPagingStrategy {
     @Override
     protected BooleanExpression applyCursor(NovelCursor cursor) {
         NovelLikeCountCursor likeCountCursor = (NovelLikeCountCursor) cursor;
-        return novel.likeCount.lt(likeCountCursor.lastLikeCount())
+        return novel.likeCount.lt(likeCountCursor.likeCount())
                 .or(
-                        novel.likeCount.eq(likeCountCursor.lastLikeCount())
+                        novel.likeCount.eq(likeCountCursor.likeCount())
                                 .and(
-                                        novel.lastEpisodePublishDate.lt(likeCountCursor.lastEpisodePublishDate())
+                                        novel.totalViewCount.lt(likeCountCursor.totalViewCount())
                                 )
                 )
                 .or(
-                        novel.likeCount.eq(likeCountCursor.lastLikeCount())
+                        novel.likeCount.eq(likeCountCursor.likeCount())
                                 .and(
-                                        novel.lastEpisodePublishDate.eq(likeCountCursor.lastEpisodePublishDate())
+                                        novel.totalViewCount.eq(likeCountCursor.totalViewCount())
                                 )
                                 .and(
-                                        novel.id.lt(likeCountCursor.lastNovelId())
+                                        novel.id.lt(likeCountCursor.novelId())
                                 )
                 );
     }
 
     @Override
     public NovelCursor createCursor(Novel lastResult) {
-        return new NovelLikeCountCursor(lastResult.getId(), lastResult.getLikeCount(), lastResult.getLastEpisodePublishDate());
+        return new NovelLikeCountCursor(lastResult.getId(), lastResult.getLikeCount(), lastResult.getTotalViewCount());
     }
 
     @Override

--- a/novelservice/src/main/java/com/iucyh/novelservice/novel/repository/query/paging/cursor/NovelLikeCountCursor.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/novel/repository/query/paging/cursor/NovelLikeCountCursor.java
@@ -1,10 +1,8 @@
 package com.iucyh.novelservice.novel.repository.query.paging.cursor;
 
-import java.time.LocalDate;
-
 public record NovelLikeCountCursor(
 
-        long lastNovelId,
-        int lastLikeCount,
-        LocalDate lastEpisodePublishDate
+        long novelId,
+        int likeCount,
+        int totalViewCount
 ) implements NovelCursor {}


### PR DESCRIPTION
## 🔖 연관된 이슈
- #132 
## 🧾 작업 내용
- 소설 목록 조회 좋아요순 정렬 기준을 다음과 같이 개편
  - 총 좋아요수
  - 총 조회수
  - pk
- 다른 NovelCursor 들과 마찬가지로 last... 네이밍 컨벤션 삭제 (컬럼 이름 자체에 last.. 가 포함된 컬럼은 예외)
## 🔍 참고자료


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **변경 사항**
  * 소설 목록 정렬 기준을 에피소드 발행일에서 조회수 기반으로 변경했습니다.
  * 페이지네이션 커서 구조를 최적화하여 조회수 기반 정렬을 더욱 효율적으로 지원하도록 개선했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->