### PR TITLE
Chore: 최신 회차 등록일 조회 메서드 개선

### DIFF
--- a/novelservice/src/main/java/com/iucyh/novelservice/episode/repository/query/EpisodeQueryRepository.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/episode/repository/query/EpisodeQueryRepository.java
@@ -30,13 +30,13 @@ public interface EpisodeQueryRepository {
     boolean episodeExistsByNovelIdAndEpisodeType(Long novelId, EpisodeType episodeType, Long id);
 
     /**
-     * <p>{@code publicId}에 해당하는 회차와 삭제된 회차를 제외한 나머지 회차 중 가장 최신 회차의 생성일 조회</p>
-     * <p>제외할 회차가 없다면 publicId에 null 전달</p>
+     * <p>{@code novelId}에 해당하는 소설에 속한 회차 중 가장 최신 회차의 생성일 조회</p>
+     * <p>전달된 {@code id}에 해당하는 회차와 삭제된 회차를 제외하고 나머지를 대상으로 조회</p>
      * @param novelId 조회할 회차들이 속한 소설의 id
-     * @param publicId 조회에서 제외할 회차의 public id (선택)
+     * @param id 추가로 제외할 회차의 pk
      * @return 가장 최신 회차의 생성일, 결과가 없다면 {@code null}
      */
-    LocalDateTime findLastEpisodeAtExceptDeletedEpisode(Long novelId, String publicId);
+    LocalDateTime findLastEpisodeAtExceptDeletedEpisode(Long novelId, Long id);
 
     /**
      * <p>현재 회차의 이전 회차 조회</p>

--- a/novelservice/src/main/java/com/iucyh/novelservice/episode/repository/query/EpisodeQueryRepositoryImpl.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/episode/repository/query/EpisodeQueryRepositoryImpl.java
@@ -59,13 +59,13 @@ public class EpisodeQueryRepositoryImpl implements EpisodeQueryRepository {
     }
 
     @Override
-    public LocalDateTime findLastEpisodeAtExceptDeletedEpisode(Long novelId, String publicId) {
+    public LocalDateTime findLastEpisodeAtExceptDeletedEpisode(Long novelId, Long id) {
         return queryFactory
                 .select(episode.createdAt)
                 .from(episode)
                 .where(
                         episode.novel.id.eq(novelId),
-                        publicId == null ? null : episode.publicId.ne(publicId),
+                        episode.id.ne(id),
                         episode.deletedAt.isNull()
                 )
                 .orderBy(

--- a/novelservice/src/main/java/com/iucyh/novelservice/episode/service/EpisodeService.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/episode/service/EpisodeService.java
@@ -81,7 +81,7 @@ public class EpisodeService {
         episode.softDelete();
 
         // 가장 최신 회차의 등록일을 가장 최신 회차 발행일로 변환 후 novel에 저장 (최신 회차 등록일 조회 시 삭제중인 회차, 삭제된 회차는 제외)
-        LocalDateTime lastEpisodeAt = episodeQueryRepository.findLastEpisodeAtExceptDeletedEpisode(novel.getId(), episode.getPublicId());
+        LocalDateTime lastEpisodeAt = episodeQueryRepository.findLastEpisodeAtExceptDeletedEpisode(novel.getId(), episode.getId());
         LocalDate lastEpisodePublishDate = toLastEpisodePublishDate(lastEpisodeAt);
 
         // 소설에 더 이상 회차가 한개도 존재하지 않으면 자연스럽게 null로 설정


### PR DESCRIPTION
## 🔖 연관된 이슈
- #134 
## 🧾 작업 내용
- 최신 회차 등록일 조회 메서드에서 제외할 회차의 식별자로 publicId가 아니라 id (pk) 를 받도록 개선 (내부에서만 쓰이고, 외부에서 쓰일 일이 없으므로)
- 제외할 회차의 식별자를 선택이 아니라 필수로 받도록 수정 (서비스 레이어에서 제외할 회차가 있냐 없냐에 따라 분기 처리하는 로직도 없고, 추후 다른 로직에서 최신 회차 등록일을 조회할 때 제외할 회차가 없을 수 있다면 오버로딩을 하는 것이 더 깔끔하므로)
## 🔍 참고자료


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **개선 사항**
  * 에피소드 조회 및 처리 로직 개선

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->