### PR TITLE
Chore: Episode PrevNext Query Projection 필드 네이밍 개선

### DIFF
--- a/novelservice/src/main/java/com/iucyh/novelservice/episode/repository/query/projection/EpisodePrevNextQueryProjection.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/episode/repository/query/projection/EpisodePrevNextQueryProjection.java
@@ -7,6 +7,6 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class EpisodePrevNextQueryProjection {
 
-    private final String episodePublicId;
+    private final String publicId;
     private final Integer episodeNumber;
 }

--- a/novelservice/src/main/java/com/iucyh/novelservice/episode/web/dto/mapper/EpisodeResponseMapper.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/episode/web/dto/mapper/EpisodeResponseMapper.java
@@ -82,11 +82,11 @@ public class EpisodeResponseMapper {
         EpisodeDetailResponse.EpisodePrevNextItem nextEpisode = null;
 
         if (prev != null) {
-            prevEpisode = new EpisodeDetailResponse.EpisodePrevNextItem(prev.getEpisodePublicId(), prev.getEpisodeNumber());
+            prevEpisode = new EpisodeDetailResponse.EpisodePrevNextItem(prev.getPublicId(), prev.getEpisodeNumber());
         }
 
         if (next != null) {
-            nextEpisode = new EpisodeDetailResponse.EpisodePrevNextItem(next.getEpisodePublicId(), next.getEpisodeNumber());
+            nextEpisode = new EpisodeDetailResponse.EpisodePrevNextItem(next.getPublicId(), next.getEpisodeNumber());
         }
 
         return new EpisodeDetailResponse.EpisodePrevNext(prevEpisode, nextEpisode);


### PR DESCRIPTION
## 🔖 연관된 이슈
- #136 
## 🧾 작업 내용
- 단일 엔티티 조회를 위한 query projection 에서는 컬럼명 앞에 엔티티의 이름을 명시하지 않고 있으므로 일관성을 위해 episodePublicId -> publicId 로 네이밍 변경
## 🔍 참고자료


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **리팩토링**
  * 내부 필드명 정정으로 코드 일관성 강화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->