### PR TITLE
Refactoring: novel has_common_episode 컬럼 삭제

### DIFF
--- a/novelservice/docker/db/mysql/init/100-schema.sql
+++ b/novelservice/docker/db/mysql/init/100-schema.sql
@@ -24,7 +24,6 @@ CREATE TABLE `novel`
     description               VARCHAR(500) NOT NULL DEFAULT '',
     category                  VARCHAR(50)  NOT NULL,
     common_episode_count      INT          NOT NULL DEFAULT 0,
-    has_common_episode        BOOLEAN      NOT NULL DEFAULT FALSE,
     like_count                INT          NOT NULL DEFAULT 0,
     total_view_count          INT          NOT NULL DEFAULT 0,
     period_view_count         INT          NOT NULL DEFAULT 0,

--- a/novelservice/src/main/java/com/iucyh/novelservice/episode/repository/query/EpisodeQueryRepository.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/episode/repository/query/EpisodeQueryRepository.java
@@ -20,16 +20,6 @@ public interface EpisodeQueryRepository {
     boolean episodeExistsByNovelIdAndEpisodeType(Long novelId, EpisodeType episodeType);
 
     /**
-     * <p>{@code novelId}에 해당하는 소설에 종류가 {@code episodeType}인 회차가 존재하는지 검사</p>
-     * <p>전달된 {@code id}에 해당하는 회차와 삭제된 회차를 제외하고 나머지를 대상으로 검사</p>
-     * @param novelId 검사할 소설의 id
-     * @param episodeType 검사할 회차 종류
-     * @param id 추가로 제외할 회차의 pk
-     * @return 조건이 맞는 회차가 존재하면 {@code true}, 아니라면 {@code false}
-     */
-    boolean episodeExistsByNovelIdAndEpisodeType(Long novelId, EpisodeType episodeType, Long id);
-
-    /**
      * <p>{@code novelId}에 해당하는 소설에 속한 회차 중 가장 최신 회차의 생성일 조회</p>
      * <p>전달된 {@code id}에 해당하는 회차와 삭제된 회차를 제외하고 나머지를 대상으로 조회</p>
      * @param novelId 조회할 회차들이 속한 소설의 id

--- a/novelservice/src/main/java/com/iucyh/novelservice/episode/repository/query/EpisodeQueryRepositoryImpl.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/episode/repository/query/EpisodeQueryRepositoryImpl.java
@@ -44,21 +44,6 @@ public class EpisodeQueryRepositoryImpl implements EpisodeQueryRepository {
     }
 
     @Override
-    public boolean episodeExistsByNovelIdAndEpisodeType(Long novelId, EpisodeType episodeType, Long id) {
-        Integer result = queryFactory
-                .selectOne()
-                .from(episode)
-                .where(
-                        episode.novel.id.eq(novelId),
-                        episode.episodeType.eq(episodeType),
-                        episode.id.ne(id),
-                        episode.deletedAt.isNull()
-                )
-                .fetchFirst();
-        return result != null;
-    }
-
-    @Override
     public LocalDateTime findLastEpisodeAtExceptDeletedEpisode(Long novelId, Long id) {
         return queryFactory
                 .select(episode.createdAt)

--- a/novelservice/src/main/java/com/iucyh/novelservice/episode/service/EpisodeService.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/episode/service/EpisodeService.java
@@ -52,7 +52,6 @@ public class EpisodeService {
         // COMMON 회차 생성 시 관련 컬럼 업데이트
         if (command.episodeType() == EpisodeType.COMMON) {
             novel.updateMaxEpisodeNumber(savedEpisode.getEpisodeNumber());
-            novel.updateHasCommonEpisode(true);
             novelRepository.increaseCommonEpisodeCount(novel.getId());
         }
 
@@ -89,12 +88,6 @@ public class EpisodeService {
 
         // COMMON 회차와 관련된 컬럼 업데이트 (삭제하려는 회차가 COMMON이 아니라면 COMMON과 관련된 상태는 변하지 않으므로 업데이트 스킵)
         if (episode.getEpisodeType() == EpisodeType.COMMON) {
-            boolean hasCommonEpisode = episodeQueryRepository.episodeExistsByNovelIdAndEpisodeType(novel.getId(), EpisodeType.COMMON, episode.getId());
-            if (!hasCommonEpisode) {
-                // novel에 더 이상 일반 회차가 한개도 존재하지 않으면 hasCommonEpisode를 false로 변경 (회차 존재 여부 조회 시 삭제중인 회차, 삭제된 회차는 제외)
-                novel.updateHasCommonEpisode(false);
-            }
-
             // DB 레벨에서 음수값 방지
             novelRepository.decreaseCommonEpisodeCount(novel.getId());
         }

--- a/novelservice/src/main/java/com/iucyh/novelservice/novel/domain/Novel.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/novel/domain/Novel.java
@@ -52,9 +52,6 @@ public class Novel extends PublicEntity {
     private LocalDate lastEpisodePublishDate;
 
     @Column(nullable = false)
-    private Boolean hasCommonEpisode = false;
-
-    @Column(nullable = false)
     private Boolean isCompleted = false;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -87,12 +84,6 @@ public class Novel extends PublicEntity {
     public void updateCategory(NovelCategory category) {
         if (category != null) {
             this.category = category;
-        }
-    }
-
-    public void updateHasCommonEpisode(Boolean hasCommonEpisode) {
-        if (!this.hasCommonEpisode.equals(hasCommonEpisode)) {
-            this.hasCommonEpisode = hasCommonEpisode;
         }
     }
 

--- a/novelservice/src/main/java/com/iucyh/novelservice/novel/repository/query/NovelQueryRepositoryImpl.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/novel/repository/query/NovelQueryRepositoryImpl.java
@@ -94,7 +94,7 @@ public class NovelQueryRepositoryImpl implements NovelQueryRepository {
      */
     private BooleanExpression applyValidNovelFilter() {
         return novel.deletedAt.isNull()
-                .and(novel.hasCommonEpisode.isTrue());
+                .and(novel.commonEpisodeCount.gt(0));
     }
 
     private BooleanExpression applyCategoryFilter(NovelCategory category) {


### PR DESCRIPTION
## 🔖 연관된 이슈
- #138
## 🧾 작업 내용
- has_common_episode 컬럼 삭제 및 관련 코드 수정
## 🔍 참고자료
-- 목적 --
common_episode_count > 0 과 커서 조건 둘 다 range 이므로 이론적으로 인덱스 효율이 제대로 나오지 않을 것 같다고 생각했지만, 실제 테스트에서는 소설 10만개 중 50% 정도가 common_episode_count = 0 이어도 인덱스에서 대략 200-500 row 정도만 스캔하며 db 기준 2-5ms, 애플리케이션 기준 30-40ms 정도가 나오고 있었습니다. 그래서 has_common_episode 를 둠으로써 생기는 정합성 및 동시성 관리 비용과 삭제 시 일반 회차 존재 여부를 확인하기 위한 exists 쿼리 오버헤드에 비해 성능 차이는 크지 않아 굳이 추가 컬럼을 둘 이유가 없습니다. 심지어 is_new(혹은 created_at between), is_completed 같은 추가 플래그를 조건으로 넣고, 인덱스를 정렬에 쓰이는 값들로만 잡아도 속도가 엄청나게 느려지지 않기 때문에 아직은 불필요한 컬럼이라고 판단했습니다.

-- 이유 --
애초에 쿼리에 쓰이는 정렬 기준들이 대부분 회차가 존재해야 집계되는 컬럼들이기 때문에 회차가 없는(common_episode_count 가 0인) 소설들은 대부분 인덱스 하위로 몰리게 됩니다.  그래서 현실적으로 인덱스 상위 몇백개 정도만 스캔하면 limit 50을 채울 수 있어 속도 차이가 크지 않은 것으로 보입니다. 
또한 사용자 화면을 위한 정렬에서 인기도와 관련되지 않은 컬럼을 정렬 기준으로 쓸 일은 적고, 회차가 없는 소설도 극초반이 아니라면 50%를 넘기기 힘들기 때문에 아직은 굳이 has_common_episode 같은 추가 컬럼을 둘 필요는 없어보입니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **리팩토링**
  * 소설의 공통 에피소드 추적 방식을 최적화했습니다. 기존의 boolean 플래그에서 카운트 기반 시스템으로 변경되었으며, 사용자에게 보여지는 기능은 동일합니다.
  * 에피소드 관리 로직을 간소화하여 코드 유지보수성을 개선했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->