### PR TITLE
Feature: 신작 소설 필터 조건 개선

### DIFF
--- a/novelservice/src/main/java/com/iucyh/novelservice/novel/repository/query/NovelQueryRepositoryImpl.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/novel/repository/query/NovelQueryRepositoryImpl.java
@@ -12,7 +12,6 @@ import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
 import java.time.LocalTime;
-import java.time.temporal.TemporalAdjuster;
 import java.time.temporal.TemporalAdjusters;
 import java.util.List;
 

--- a/novelservice/src/main/java/com/iucyh/novelservice/novel/repository/query/NovelQueryRepositoryImpl.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/novel/repository/query/NovelQueryRepositoryImpl.java
@@ -11,6 +11,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.temporal.TemporalAdjuster;
+import java.time.temporal.TemporalAdjusters;
 import java.util.List;
 
 import static com.iucyh.novelservice.novel.domain.QNovel.novel;
@@ -68,14 +71,13 @@ public class NovelQueryRepositoryImpl implements NovelQueryRepository {
 
     @Override
     public List<Novel> findNewNovels(NovelPagingCondition condition, NovelPagingStrategy strategy, NovelCategory category) {
-        LocalDateTime thisMonth = getThisMonth();
         JPAQuery<Novel> query = queryFactory
                 .selectFrom(novel)
                 .join(novel.user, user).fetchJoin()
                 .where(
                         applyValidNovelFilter(),
                         applyCategoryFilter(category),
-                        novel.createdAt.goe(thisMonth)
+                        applyNewNovelFilter()
                 )
                 .limit(condition.limit());
 
@@ -101,12 +103,17 @@ public class NovelQueryRepositoryImpl implements NovelQueryRepository {
         return category == null ? null : novel.category.eq(category);
     }
 
-    private LocalDateTime getThisMonth() {
-        return LocalDateTime.now()
-                .withDayOfMonth(1)
-                .withHour(0)
-                .withMinute(0)
-                .withSecond(0)
-                .withNano(0);
+    /**
+     * <p>신작 소설만 조회하기 위한 필터 적용</p>
+     */
+    private BooleanExpression applyNewNovelFilter() {
+        LocalDateTime now = LocalDateTime.now();
+        return novel.createdAt.goe(
+                now.with(TemporalAdjusters.firstDayOfMonth()).with(LocalTime.MIN)
+        ).and(
+                novel.createdAt.lt(
+                        now.with(TemporalAdjusters.firstDayOfNextMonth()).with(LocalTime.MIN)
+                )
+        );
     }
 }


### PR DESCRIPTION
## 🔖 연관된 이슈
- #140 
## 🧾 작업 내용
- 신작 소설 필터링 조건을 created_at >= (이번달 첫 일) and created_at < (다음달 첫 일) 로 변경
## 🔍 참고자료
- 현재는 신작 필터링 조건이 created_at >= ? 밖에 없습니다. 물론 미래의 시간으로 소설이 생성될 가능성은 없어서 이 조건만으로도 한 달 안에 생성된 소설들만 나올 가능성이 높지만 더 명확히 결과를 보장하기 위해 created_at >= (이번 달 첫 일) and created_at < (다음 달 첫 일) 로 변경합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 신작 도서 필터링 시 월 경계 계산 로직을 개선하여 조회 정확도를 향상했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->