### PR TITLE
Fix: 소설 목록 조회 시 특정 정렬 기준의 NovelCursor 객체가 다른 정렬 기준에도 호환되는 버그 수정

### DIFF
--- a/novelservice/src/main/java/com/iucyh/novelservice/novel/repository/query/paging/NovelLastUpdatePagingStrategy.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/novel/repository/query/paging/NovelLastUpdatePagingStrategy.java
@@ -26,20 +26,20 @@ public class NovelLastUpdatePagingStrategy extends AbstractNovelPagingStrategy {
     @Override
     protected BooleanExpression applyCursor(NovelCursor cursor) {
         NovelLastUpdateCursor lastUpdateCursor = (NovelLastUpdateCursor) cursor;
-        return novel.lastEpisodePublishDate.lt(lastUpdateCursor.lastEpisodePublishDate())
+        return novel.lastEpisodePublishDate.lt(lastUpdateCursor.getLastEpisodePublishDate())
                 .or(
-                        novel.lastEpisodePublishDate.eq(lastUpdateCursor.lastEpisodePublishDate())
+                        novel.lastEpisodePublishDate.eq(lastUpdateCursor.getLastEpisodePublishDate())
                                 .and(
-                                        novel.totalViewCount.lt(lastUpdateCursor.totalViewCount())
+                                        novel.totalViewCount.lt(lastUpdateCursor.getTotalViewCount())
                                 )
                 )
                 .or(
-                        novel.lastEpisodePublishDate.eq(lastUpdateCursor.lastEpisodePublishDate())
+                        novel.lastEpisodePublishDate.eq(lastUpdateCursor.getLastEpisodePublishDate())
                                 .and(
-                                        novel.totalViewCount.eq(lastUpdateCursor.totalViewCount())
+                                        novel.totalViewCount.eq(lastUpdateCursor.getTotalViewCount())
                                 )
                                 .and(
-                                        novel.id.lt(lastUpdateCursor.novelId())
+                                        novel.id.lt(lastUpdateCursor.getNovelId())
                                 )
                 );
     }
@@ -52,7 +52,7 @@ public class NovelLastUpdatePagingStrategy extends AbstractNovelPagingStrategy {
 
     @Override
     public NovelCursor createCursor(Novel lastResult) {
-        return new NovelLastUpdateCursor(lastResult.getId(), lastResult.getLastEpisodePublishDate(), lastResult.getTotalViewCount());
+        return NovelLastUpdateCursor.of(lastResult.getId(), lastResult.getLastEpisodePublishDate(), lastResult.getTotalViewCount());
     }
 
     @Override

--- a/novelservice/src/main/java/com/iucyh/novelservice/novel/repository/query/paging/NovelLikeCountPagingStrategy.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/novel/repository/query/paging/NovelLikeCountPagingStrategy.java
@@ -26,27 +26,27 @@ public class NovelLikeCountPagingStrategy extends AbstractNovelPagingStrategy {
     @Override
     protected BooleanExpression applyCursor(NovelCursor cursor) {
         NovelLikeCountCursor likeCountCursor = (NovelLikeCountCursor) cursor;
-        return novel.likeCount.lt(likeCountCursor.likeCount())
+        return novel.likeCount.lt(likeCountCursor.getLikeCount())
                 .or(
-                        novel.likeCount.eq(likeCountCursor.likeCount())
+                        novel.likeCount.eq(likeCountCursor.getLikeCount())
                                 .and(
-                                        novel.totalViewCount.lt(likeCountCursor.totalViewCount())
+                                        novel.totalViewCount.lt(likeCountCursor.getTotalViewCount())
                                 )
                 )
                 .or(
-                        novel.likeCount.eq(likeCountCursor.likeCount())
+                        novel.likeCount.eq(likeCountCursor.getLikeCount())
                                 .and(
-                                        novel.totalViewCount.eq(likeCountCursor.totalViewCount())
+                                        novel.totalViewCount.eq(likeCountCursor.getTotalViewCount())
                                 )
                                 .and(
-                                        novel.id.lt(likeCountCursor.novelId())
+                                        novel.id.lt(likeCountCursor.getNovelId())
                                 )
                 );
     }
 
     @Override
     public NovelCursor createCursor(Novel lastResult) {
-        return new NovelLikeCountCursor(lastResult.getId(), lastResult.getLikeCount(), lastResult.getTotalViewCount());
+        return NovelLikeCountCursor.of(lastResult.getId(), lastResult.getLikeCount(), lastResult.getTotalViewCount());
     }
 
     @Override

--- a/novelservice/src/main/java/com/iucyh/novelservice/novel/repository/query/paging/NovelPopularPagingStrategy.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/novel/repository/query/paging/NovelPopularPagingStrategy.java
@@ -26,20 +26,20 @@ public class NovelPopularPagingStrategy extends AbstractNovelPagingStrategy {
     @Override
     protected BooleanExpression applyCursor(NovelCursor cursor) {
         NovelPopularCursor popularCursor = (NovelPopularCursor) cursor;
-        return novel.periodViewCount.lt(popularCursor.periodViewCount())
+        return novel.periodViewCount.lt(popularCursor.getPeriodViewCount())
                 .or(
-                        novel.periodViewCount.eq(popularCursor.periodViewCount())
+                        novel.periodViewCount.eq(popularCursor.getPeriodViewCount())
                                 .and(
-                                        novel.lastEpisodePublishDate.lt(popularCursor.lastEpisodePublishDate())
+                                        novel.lastEpisodePublishDate.lt(popularCursor.getLastEpisodePublishDate())
                                 )
                 )
                 .or(
-                        novel.periodViewCount.eq(popularCursor.periodViewCount())
+                        novel.periodViewCount.eq(popularCursor.getPeriodViewCount())
                                 .and(
-                                        novel.lastEpisodePublishDate.eq(popularCursor.lastEpisodePublishDate())
+                                        novel.lastEpisodePublishDate.eq(popularCursor.getLastEpisodePublishDate())
                                 )
                                 .and(
-                                        novel.id.lt(popularCursor.novelId())
+                                        novel.id.lt(popularCursor.getNovelId())
                                 )
                 );
     }
@@ -52,7 +52,7 @@ public class NovelPopularPagingStrategy extends AbstractNovelPagingStrategy {
 
     @Override
     public NovelCursor createCursor(Novel lastResult) {
-        return new NovelPopularCursor(lastResult.getId(), lastResult.getPeriodViewCount(), lastResult.getLastEpisodePublishDate());
+        return NovelPopularCursor.of(lastResult.getId(), lastResult.getPeriodViewCount(), lastResult.getLastEpisodePublishDate());
     }
 
     @Override

--- a/novelservice/src/main/java/com/iucyh/novelservice/novel/repository/query/paging/NovelViewCountPagingStrategy.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/novel/repository/query/paging/NovelViewCountPagingStrategy.java
@@ -26,20 +26,20 @@ public class NovelViewCountPagingStrategy extends AbstractNovelPagingStrategy {
     @Override
     protected BooleanExpression applyCursor(NovelCursor cursor) {
         NovelViewCountCursor viewCountCursor = (NovelViewCountCursor) cursor;
-        return novel.totalViewCount.lt(viewCountCursor.totalViewCount())
+        return novel.totalViewCount.lt(viewCountCursor.getTotalViewCount())
                 .or(
-                        novel.totalViewCount.eq(viewCountCursor.totalViewCount())
+                        novel.totalViewCount.eq(viewCountCursor.getTotalViewCount())
                                 .and(
-                                        novel.lastEpisodePublishDate.lt(viewCountCursor.lastEpisodePublishDate())
+                                        novel.lastEpisodePublishDate.lt(viewCountCursor.getLastEpisodePublishDate())
                                 )
                 )
                 .or(
-                        novel.totalViewCount.eq(viewCountCursor.totalViewCount())
+                        novel.totalViewCount.eq(viewCountCursor.getTotalViewCount())
                                 .and(
-                                        novel.lastEpisodePublishDate.eq(viewCountCursor.lastEpisodePublishDate())
+                                        novel.lastEpisodePublishDate.eq(viewCountCursor.getLastEpisodePublishDate())
                                 )
                                 .and(
-                                        novel.id.lt(viewCountCursor.novelId())
+                                        novel.id.lt(viewCountCursor.getNovelId())
                                 )
                 );
     }
@@ -52,7 +52,7 @@ public class NovelViewCountPagingStrategy extends AbstractNovelPagingStrategy {
 
     @Override
     public NovelCursor createCursor(Novel lastResult) {
-        return new NovelViewCountCursor(lastResult.getId(), lastResult.getTotalViewCount(), lastResult.getLastEpisodePublishDate());
+        return NovelViewCountCursor.of(lastResult.getId(), lastResult.getTotalViewCount(), lastResult.getLastEpisodePublishDate());
     }
 
     @Override

--- a/novelservice/src/main/java/com/iucyh/novelservice/novel/repository/query/paging/cursor/NovelCursor.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/novel/repository/query/paging/cursor/NovelCursor.java
@@ -4,13 +4,13 @@ import com.iucyh.novelservice.novel.enumtype.NovelSortType;
 
 /**
  * <p>Novel의 페이징에서 사용되는 커서들의 기본 타입</p>
- * <b>모든 Novel 페이징 커서 record들은 이 인터페이스를 구현해야 합니다.</b>
+ * <b>모든 Novel 페이징 커서 클래스들은 이 인터페이스를 구현해야 합니다.</b>
  */
 public interface NovelCursor {
 
     /**
      * <p>커서가 대표하는 정렬 기준(e.g. NovelPopularCursor -> NovelSortType.POPULAR)</p>
-     * <p>* 각 커서 클래스에서 구현 시 정렬 기준들만 인자로 받는 정적 팩토리 메서드(of)를 구현하여 sortType 필드는 내부적으로 직접 설정하도록 하는 것을 권장(외부에서 받으면 잘못된 NovelSortType이 전달될 가능성이 있으므로)</p>
+     * <p>* 각 커서 클래스에서 구현 시 정렬 기준들만 인자로 받는 정적 팩토리 메서드(of)를 구현하고, sortType 필드는 내부적으로 직접 설정하도록 하는 것을 권장(외부에서 받으면 잘못된 NovelSortType이 전달될 가능성이 있으므로)</p>
      */
-    NovelSortType getSortType(); // 서로 다른 정렬 기준끼리 커서가 호환되는 문제 방지용
+    NovelSortType getSortType();
 }

--- a/novelservice/src/main/java/com/iucyh/novelservice/novel/repository/query/paging/cursor/NovelCursor.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/novel/repository/query/paging/cursor/NovelCursor.java
@@ -1,8 +1,16 @@
 package com.iucyh.novelservice.novel.repository.query.paging.cursor;
 
+import com.iucyh.novelservice.novel.enumtype.NovelSortType;
+
 /**
  * <p>Novel의 페이징에서 사용되는 커서들의 기본 타입</p>
- * <b>모든 페이징 커서 record들은 이 인터페이스를 구현해야 합니다.</b>
+ * <b>모든 Novel 페이징 커서 record들은 이 인터페이스를 구현해야 합니다.</b>
  */
 public interface NovelCursor {
+
+    /**
+     * <p>커서가 대표하는 정렬 기준(e.g. NovelPopularCursor -> NovelSortType.POPULAR)</p>
+     * <p>* 각 커서 클래스에서 구현 시 정렬 기준들만 인자로 받는 정적 팩토리 메서드(of)를 구현하여 sortType 필드는 내부적으로 직접 설정하도록 하는 것을 권장(외부에서 받으면 잘못된 NovelSortType이 전달될 가능성이 있으므로)</p>
+     */
+    NovelSortType getSortType(); // 서로 다른 정렬 기준끼리 커서가 호환되는 문제 방지용
 }

--- a/novelservice/src/main/java/com/iucyh/novelservice/novel/repository/query/paging/cursor/NovelLastUpdateCursor.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/novel/repository/query/paging/cursor/NovelLastUpdateCursor.java
@@ -1,10 +1,22 @@
 package com.iucyh.novelservice.novel.repository.query.paging.cursor;
 
+import com.iucyh.novelservice.novel.enumtype.NovelSortType;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
 import java.time.LocalDate;
 
-public record NovelLastUpdateCursor(
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class NovelLastUpdateCursor implements NovelCursor {
 
-        long novelId,
-        LocalDate lastEpisodePublishDate,
-        int totalViewCount
-) implements NovelCursor {}
+    private final NovelSortType sortType;
+    private final long novelId;
+    private final LocalDate lastEpisodePublishDate;
+    private final int totalViewCount;
+
+    public static NovelLastUpdateCursor of(long novelId, LocalDate lastEpisodePublishDate, int totalViewCount) {
+        return new NovelLastUpdateCursor(NovelSortType.LAST_UPDATE, novelId, lastEpisodePublishDate, totalViewCount);
+    }
+}

--- a/novelservice/src/main/java/com/iucyh/novelservice/novel/repository/query/paging/cursor/NovelLikeCountCursor.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/novel/repository/query/paging/cursor/NovelLikeCountCursor.java
@@ -1,8 +1,20 @@
 package com.iucyh.novelservice.novel.repository.query.paging.cursor;
 
-public record NovelLikeCountCursor(
+import com.iucyh.novelservice.novel.enumtype.NovelSortType;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 
-        long novelId,
-        int likeCount,
-        int totalViewCount
-) implements NovelCursor {}
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class NovelLikeCountCursor implements NovelCursor {
+
+    private final NovelSortType sortType;
+    private final long novelId;
+    private final int likeCount;
+    private final int totalViewCount;
+
+    public static NovelLikeCountCursor of(long novelId, int likeCount, int totalViewCount) {
+        return new NovelLikeCountCursor(NovelSortType.LIKE_COUNT, novelId, likeCount, totalViewCount);
+    }
+}

--- a/novelservice/src/main/java/com/iucyh/novelservice/novel/repository/query/paging/cursor/NovelPopularCursor.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/novel/repository/query/paging/cursor/NovelPopularCursor.java
@@ -1,10 +1,22 @@
 package com.iucyh.novelservice.novel.repository.query.paging.cursor;
 
+import com.iucyh.novelservice.novel.enumtype.NovelSortType;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
 import java.time.LocalDate;
 
-public record NovelPopularCursor(
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class NovelPopularCursor implements NovelCursor {
 
-        long novelId,
-        int periodViewCount,
-        LocalDate lastEpisodePublishDate
-) implements NovelCursor {}
+    private final NovelSortType sortType;
+    private final long novelId;
+    private final int periodViewCount;
+    private final LocalDate lastEpisodePublishDate;
+
+    public static NovelPopularCursor of(long novelId, int periodViewCount, LocalDate lastEpisodePublishDate) {
+        return new NovelPopularCursor(NovelSortType.POPULAR, novelId, periodViewCount, lastEpisodePublishDate);
+    }
+}

--- a/novelservice/src/main/java/com/iucyh/novelservice/novel/repository/query/paging/cursor/NovelViewCountCursor.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/novel/repository/query/paging/cursor/NovelViewCountCursor.java
@@ -1,10 +1,22 @@
 package com.iucyh.novelservice.novel.repository.query.paging.cursor;
 
+import com.iucyh.novelservice.novel.enumtype.NovelSortType;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
 import java.time.LocalDate;
 
-public record NovelViewCountCursor(
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class NovelViewCountCursor implements NovelCursor {
 
-        long novelId,
-        int totalViewCount,
-        LocalDate lastEpisodePublishDate
-) implements NovelCursor {}
+    private final NovelSortType sortType;
+    private final long novelId;
+    private final int totalViewCount;
+    private final LocalDate lastEpisodePublishDate;
+
+    public static NovelViewCountCursor of(long novelId, int totalViewCount, LocalDate lastEpisodePublishDate) {
+        return new NovelViewCountCursor(NovelSortType.VIEW_COUNT, novelId, totalViewCount, lastEpisodePublishDate);
+    }
+}

--- a/novelservice/src/main/java/com/iucyh/novelservice/novel/service/NovelQueryService.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/novel/service/NovelQueryService.java
@@ -68,7 +68,7 @@ public class NovelQueryService {
             BiFunction<NovelPagingCondition, NovelPagingStrategy, List<Novel>> finder
     ) {
         NovelCursor decodedCursor = null;
-        if (cursor != null) {
+        if (cursor != null && !cursor.isBlank()) {
             decodedCursor = cursorCodec.decode(cursor, sortType.getSupportedCursorClass());
             // JSON은 필드 순서를 신경쓰지 않기 때문에 필드명만 같다면 서로 다른 정렬 기준끼리도 커서가 호환될 수 있으므로 별도로 추가 검증
             novelPolicyValidator.validateNovelCursorMatchesSortType(decodedCursor, sortType);

--- a/novelservice/src/main/java/com/iucyh/novelservice/novel/service/NovelQueryService.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/novel/service/NovelQueryService.java
@@ -8,6 +8,7 @@ import com.iucyh.novelservice.novel.service.codec.NovelCursorCodec;
 import com.iucyh.novelservice.novel.service.dto.query.GetNewNovelsQuery;
 import com.iucyh.novelservice.novel.service.dto.query.GetNovelsQuery;
 import com.iucyh.novelservice.novel.service.factory.NovelPagingStrategyFactory;
+import com.iucyh.novelservice.novel.service.policy.NovelPolicyValidator;
 import com.iucyh.novelservice.novel.web.dto.mapper.NovelResponseMapper;
 import com.iucyh.novelservice.novel.web.dto.response.NovelDetailResponse;
 import com.iucyh.novelservice.novel.web.dto.response.NovelSummaryResponse;
@@ -32,6 +33,8 @@ public class NovelQueryService {
     private final NovelPagingStrategyFactory pagingStrategyFactory;
     private final NovelRepository novelRepository;
     private final NovelQueryRepository novelQueryRepository;
+
+    private final NovelPolicyValidator novelPolicyValidator;
 
     public PageWithCursorResponse<NovelSummaryResponse> getNovels(GetNovelsQuery query) {
         return findNovels(query.sortType(), query.cursor(), query.limit(),
@@ -64,8 +67,15 @@ public class NovelQueryService {
             NovelSortType sortType, String cursor, int limit,
             BiFunction<NovelPagingCondition, NovelPagingStrategy, List<Novel>> finder
     ) {
+        NovelCursor decodedCursor = null;
+        if (cursor != null) {
+            decodedCursor = cursorCodec.decode(cursor, sortType.getSupportedCursorClass());
+            // JSON은 필드 순서를 신경쓰지 않기 때문에 필드명만 같다면 서로 다른 정렬 기준끼리도 커서가 호환될 수 있으므로 별도로 추가 검증
+            novelPolicyValidator.validateNovelCursorMatchesSortType(decodedCursor, sortType);
+        }
+
         // 다음 페이지가 있는지 확인하기 위해 limit + 1개 만큼 가져오기(결과의 size가 limit + 1 이라면 다음 페이지 존재)
-        NovelPagingCondition pagingCondition = createPagingCondition(sortType, cursor, limit + 1);
+        NovelPagingCondition pagingCondition = new NovelPagingCondition(decodedCursor, limit + 1);
         NovelPagingStrategy pagingStrategy = pagingStrategyFactory.get(sortType);
 
         List<Novel> result = finder.apply(pagingCondition, pagingStrategy);
@@ -84,11 +94,6 @@ public class NovelQueryService {
 
         List<NovelSummaryResponse> novels = mapToNovelResponseList(pageResult);
         return NovelResponseMapper.toPageResponse(novels, newCursor, limit);
-    }
-
-    private NovelPagingCondition createPagingCondition(NovelSortType sortType, String encodedCursor, int limit) {
-        NovelCursor decodedCursor = cursorCodec.decode(encodedCursor, sortType.getSupportedCursorClass());
-        return new NovelPagingCondition(decodedCursor, limit);
     }
 
     private List<NovelSummaryResponse> mapToNovelResponseList(List<Novel> novels) {

--- a/novelservice/src/main/java/com/iucyh/novelservice/novel/service/codec/NovelBase64CursorCodec.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/novel/service/codec/NovelBase64CursorCodec.java
@@ -23,10 +23,6 @@ public class NovelBase64CursorCodec implements NovelCursorCodec {
             return null;
         }
 
-        try {
-            return base64Util.decode(cursor, type);
-        } catch (RuntimeException e) {
-            throw new InvalidNovelCursor();
-        }
+        return base64Util.decode(cursor, type);
     }
 }

--- a/novelservice/src/main/java/com/iucyh/novelservice/novel/service/codec/NovelBase64CursorCodec.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/novel/service/codec/NovelBase64CursorCodec.java
@@ -18,7 +18,7 @@ public class NovelBase64CursorCodec implements NovelCursorCodec {
     }
 
     @Override
-    public <T extends NovelCursor> NovelCursor decode(String cursor, Class<T> type) throws InvalidNovelCursor {
+    public <T extends NovelCursor> T decode(String cursor, Class<T> type) {
         if (cursor == null || cursor.isBlank()) {
             return null;
         }

--- a/novelservice/src/main/java/com/iucyh/novelservice/novel/service/codec/NovelCursorCodec.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/novel/service/codec/NovelCursorCodec.java
@@ -1,6 +1,5 @@
 package com.iucyh.novelservice.novel.service.codec;
 
-import com.iucyh.novelservice.novel.exception.InvalidNovelCursor;
 import com.iucyh.novelservice.novel.repository.query.paging.cursor.NovelCursor;
 
 public interface NovelCursorCodec {
@@ -18,5 +17,5 @@ public interface NovelCursorCodec {
      * @param type 디코딩 될 {@code NovelCursor} Class
      * @return 전달된 문자열 값을 기반으로 디코딩 된 {@code NovelCursor}
      */
-    <T extends NovelCursor> NovelCursor decode(String cursor, Class<T> type);
+    <T extends NovelCursor> T decode(String cursor, Class<T> type);
 }

--- a/novelservice/src/main/java/com/iucyh/novelservice/novel/service/codec/NovelCursorCodec.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/novel/service/codec/NovelCursorCodec.java
@@ -17,7 +17,6 @@ public interface NovelCursorCodec {
      * @param cursor 디코딩 할 문자열 값
      * @param type 디코딩 될 {@code NovelCursor} Class
      * @return 전달된 문자열 값을 기반으로 디코딩 된 {@code NovelCursor}
-     * @throws InvalidNovelCursor 디코딩 실패 시(해당 type으로 디코딩이 불가능하거나, 기타 여러 이유로 디코딩이 실패할 때)
      */
-    <T extends NovelCursor> NovelCursor decode(String cursor, Class<T> type) throws InvalidNovelCursor;
+    <T extends NovelCursor> NovelCursor decode(String cursor, Class<T> type);
 }

--- a/novelservice/src/main/java/com/iucyh/novelservice/novel/service/policy/NovelPolicyValidator.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/novel/service/policy/NovelPolicyValidator.java
@@ -19,9 +19,9 @@ public class NovelPolicyValidator {
 
     /**
      * <p>{@code cursor}가 반환하는 {@code NovelSortType}과 전달된 {@code sortType}이 일치하는지 검증</p>
-     * @param cursor {@code NovelCursor} 객체로 디코딩 된 클라이언트로부터 전달받은 커서
+     * @param cursor {@code NovelCursor} 객체로 디코딩된 클라이언트로부터 전달받은 커서
      * @param sortType 클라이언트로부터 전달받은 정렬 기준
-     * @throws InvalidNovelCursor 커서가 해당 정렬기준과 맞지 않을 때
+     * @throws InvalidNovelCursor 커서가 해당 정렬 기준과 맞지 않을 때
      */
     public void validateNovelCursorMatchesSortType(NovelCursor cursor, NovelSortType sortType) throws InvalidNovelCursor {
         if (cursor.getSortType() != sortType) {

--- a/novelservice/src/main/java/com/iucyh/novelservice/novel/service/policy/NovelPolicyValidator.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/novel/service/policy/NovelPolicyValidator.java
@@ -3,11 +3,10 @@ package com.iucyh.novelservice.novel.service.policy;
 import com.iucyh.novelservice.episode.enumtype.EpisodeType;
 import com.iucyh.novelservice.episode.repository.query.EpisodeQueryRepository;
 import com.iucyh.novelservice.novel.domain.Novel;
-import com.iucyh.novelservice.novel.exception.DuplicateNovelTitle;
-import com.iucyh.novelservice.novel.exception.NovelAlreadyCompleted;
-import com.iucyh.novelservice.novel.exception.NovelAlreadyHasPrologue;
-import com.iucyh.novelservice.novel.exception.NovelHasNoCommonEpisodes;
+import com.iucyh.novelservice.novel.enumtype.NovelSortType;
+import com.iucyh.novelservice.novel.exception.*;
 import com.iucyh.novelservice.novel.repository.query.NovelQueryRepository;
+import com.iucyh.novelservice.novel.repository.query.paging.cursor.NovelCursor;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -17,6 +16,18 @@ public class NovelPolicyValidator {
 
     private final NovelQueryRepository novelQueryRepository;
     private final EpisodeQueryRepository episodeQueryRepository;
+
+    /**
+     * <p>{@code cursor}가 반환하는 {@code NovelSortType}과 전달된 {@code sortType}이 일치하는지 검증</p>
+     * @param cursor NovelCursor 객체로 디코딩 된 클라이언트로부터 전달받은 커서
+     * @param sortType 클라이언트로부터 전달받은 정렬 기준
+     * @throws InvalidNovelCursor 커서가 해당 정렬기준과 맞지 않을 때
+     */
+    public void validateNovelCursorMatchesSortType(NovelCursor cursor, NovelSortType sortType) {
+        if (cursor.getSortType() != sortType) {
+            throw new InvalidNovelCursor();
+        }
+    }
 
     /**
      * <p>{@code userId}에 해당하는 유저가 작성한 소설 중 전달된 {@code title}과 중복되는 제목을 가진 소설이 없는지 검증</p>

--- a/novelservice/src/main/java/com/iucyh/novelservice/novel/service/policy/NovelPolicyValidator.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/novel/service/policy/NovelPolicyValidator.java
@@ -23,7 +23,7 @@ public class NovelPolicyValidator {
      * @param sortType 클라이언트로부터 전달받은 정렬 기준
      * @throws InvalidNovelCursor 커서가 해당 정렬기준과 맞지 않을 때
      */
-    public void validateNovelCursorMatchesSortType(NovelCursor cursor, NovelSortType sortType) {
+    public void validateNovelCursorMatchesSortType(NovelCursor cursor, NovelSortType sortType) throws InvalidNovelCursor {
         if (cursor.getSortType() != sortType) {
             throw new InvalidNovelCursor();
         }

--- a/novelservice/src/main/java/com/iucyh/novelservice/novel/service/policy/NovelPolicyValidator.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/novel/service/policy/NovelPolicyValidator.java
@@ -19,7 +19,7 @@ public class NovelPolicyValidator {
 
     /**
      * <p>{@code cursor}가 반환하는 {@code NovelSortType}과 전달된 {@code sortType}이 일치하는지 검증</p>
-     * @param cursor NovelCursor 객체로 디코딩 된 클라이언트로부터 전달받은 커서
+     * @param cursor {@code NovelCursor} 객체로 디코딩 된 클라이언트로부터 전달받은 커서
      * @param sortType 클라이언트로부터 전달받은 정렬 기준
      * @throws InvalidNovelCursor 커서가 해당 정렬기준과 맞지 않을 때
      */


### PR DESCRIPTION
## 🔖 연관된 이슈
- #144 
## 🧾 작업 내용
- 특정 정렬 기준의 NovelCursor 객체를 다른 정렬 기준에도 사용할 수 있던 문제를 수정하였습니다.
- 전달받은 NovelCursor 가 전달받은 NovelSortType과 일치하는 지 별도로 검증하게 되었으므로 NovelCursorBase64Codec에서 InavalidNovelCursor 예외를 던지던 부분을 삭제하고, Base64Util에서 던지는 RuntimeException 을 그대로 던지도록 수정하였습니다. ( == Base64Util 에서 예외가 발생하면 단순히 커서가 유효하지 않은 것이 아니라 실제로 내부적인 문제가 발생한 것으로 간주)
- 정적 팩토리 메서드를 사용하기 위해 각 NovelCursor 구현체들을 class 로 변경하였습니다.
## 🔍 참고자료


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선 사항**
  * 소설 페이징 커서 검증 강화 — 요청한 정렬 타입과 커서의 일관성 확인 기능 추가
  * 커서 표현 통일 및 인스턴스화 방식 개선(팩토리 메서드 도입)으로 페이징 안정성 향상
  * 커서 인터페이스에 정렬 타입 노출 추가로 정합성 검사 용이성 증가
  * 커서 디코딩 로직 단순화(제네릭 반환·예외 처리 축소)로 오류 가능성 및 복잡도 감소

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->