### PR TITLE
Feature: 신작 소설 필터링 시 발행일 기준으로 필터링

### DIFF
--- a/novelservice/src/main/java/com/iucyh/novelservice/novel/repository/query/NovelQueryRepositoryImpl.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/novel/repository/query/NovelQueryRepositoryImpl.java
@@ -107,10 +107,10 @@ public class NovelQueryRepositoryImpl implements NovelQueryRepository {
      */
     private BooleanExpression applyNewNovelFilter() {
         LocalDateTime now = LocalDateTime.now();
-        return novel.createdAt.goe(
+        return novel.publishedAt.goe(
                 now.with(TemporalAdjusters.firstDayOfMonth()).with(LocalTime.MIN)
         ).and(
-                novel.createdAt.lt(
+                novel.publishedAt.lt(
                         now.with(TemporalAdjusters.firstDayOfNextMonth()).with(LocalTime.MIN)
                 )
         );


### PR DESCRIPTION
## 🔖 연관된 이슈
- #154
## 🧾 작업 내용
- NovelQueryRepository 에서 신작 소설 필터링 로직의 기준을 발행일로 변경하였습니다.
## 🔍 참고자료
- 단순히 시스템 등록일이 아닌 명확하고 고정된 발행일을 기준으로 필터링 해 더 정확하고 안정적인 로직 구현


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 소설 목록 필터링 시 생성 날짜 대신 발행 날짜를 기준으로 적용하도록 수정하여 정확한 필터링 결과를 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->