### PR TITLE
Refactor: 소설 상세 조회 응답의 발행일 필드 명확성 개선

### DIFF
--- a/novelservice/src/main/java/com/iucyh/novelservice/novel/web/dto/mapper/NovelResponseMapper.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/novel/web/dto/mapper/NovelResponseMapper.java
@@ -47,7 +47,7 @@ public class NovelResponseMapper {
                 novel.getLikeCount(),
                 novel.getTotalViewCount(),
                 novel.isCompletedNovel(),
-                novel.getCreatedAt(),
+                novel.getPublishedAt(),
                 author
         );
     }

--- a/novelservice/src/main/java/com/iucyh/novelservice/novel/web/dto/response/NovelDetailResponse.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/novel/web/dto/response/NovelDetailResponse.java
@@ -15,6 +15,6 @@ public record NovelDetailResponse(
         int likeCount,
         int totalViewCount,
         boolean isCompleted,
-        LocalDateTime createdAt,
+        LocalDateTime publishedAt,
         UserBasicInfo author
 ) {}


### PR DESCRIPTION
## 🔖 연관된 이슈
- #154 
## 🧾 작업 내용
- 소설 상세 조회 응답에서 발행일의 의미로 사용되던 createdAt 필드를 publishedAt 필드로 대체하여 명확성을 개선했습니다.
## 🔍 참고자료
- 소설 상세 조회 응답의 createdAt 필드는 기존에도 발행일의 대체 필드로 사용되고 있었으므로 응답에 아예 포함되지 않아도 괜찮습니다. (createdAt -> 시스템에 등록된 시점, publishedAt -> 소설이 발행된 시점 (한번 결정되면 항상 고정))


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 소설 상세 정보에서 생성 날짜 대신 출판 날짜를 표시하도록 수정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->