### PR TITLE
Chore: EpisodeDetailQueryProjection episodeCreatedAt 필드명 변경

### DIFF
--- a/novelservice/src/main/java/com/iucyh/novelservice/episode/repository/query/projection/EpisodeDetailQueryProjection.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/episode/repository/query/projection/EpisodeDetailQueryProjection.java
@@ -14,7 +14,7 @@ public class EpisodeDetailQueryProjection {
     private final String episodeTitle;
     private final String episodeDescription;
     private final Integer episodeNumber;
-    private final LocalDateTime episodeCreatedAt;
+    private final LocalDateTime episodePublishedAt;
 
     private final Long novelId;
     private final String novelPublicId;
@@ -26,7 +26,7 @@ public class EpisodeDetailQueryProjection {
 
     @QueryProjection
     public EpisodeDetailQueryProjection(
-            String episodePublicId, EpisodeType episodeType, String episodeTitle, String episodeDescription, Integer episodeNumber, LocalDateTime episodeCreatedAt,
+            String episodePublicId, EpisodeType episodeType, String episodeTitle, String episodeDescription, Integer episodeNumber, LocalDateTime episodePublishedAt,
             Long novelId, String novelPublicId, String novelTitle, Integer novelLikeCount,
             String userPublicId, String userNickname
     ) {
@@ -35,7 +35,7 @@ public class EpisodeDetailQueryProjection {
         this.episodeTitle = episodeTitle;
         this.episodeDescription = episodeDescription;
         this.episodeNumber = episodeNumber;
-        this.episodeCreatedAt = episodeCreatedAt;
+        this.episodePublishedAt = episodePublishedAt;
 
         this.novelId = novelId;
         this.novelPublicId = novelPublicId;

--- a/novelservice/src/main/java/com/iucyh/novelservice/episode/web/dto/mapper/EpisodeResponseMapper.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/episode/web/dto/mapper/EpisodeResponseMapper.java
@@ -54,7 +54,7 @@ public class EpisodeResponseMapper {
                 episodeDetail.getEpisodeType(),
                 episodeDetail.getEpisodeTitle(),
                 episodeDetail.getEpisodeDescription(),
-                episodeDetail.getEpisodeCreatedAt(),
+                episodeDetail.getEpisodePublishedAt(),
                 novelInfo,
                 episodePrevNext
         );


### PR DESCRIPTION
## 🔖 연관된 이슈
- #161
## 🧾 작업 내용
- EpisodeDetailQueryProjection의 episodeCreatedAt 필드명을 episodePublished으로 변경하고, 관련 Mapper 코드를 수정했습니다.
## 🔍 참고
- 회차 상세 조회에서 실제로 Episode의 publishedAt 을 조회하는 로직은 추후 구현할 예정입니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 에피소드 상세 정보에서 표시되는 날짜를 발행일로 변경하여 정확성을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->