### PR TITLE
Feature: 회차 목록 조회에서 createdAt -> publishedAt 조회로 변경

### DIFF
--- a/novelservice/src/main/java/com/iucyh/novelservice/episode/repository/query/EpisodeQueryRepositoryImpl.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/episode/repository/query/EpisodeQueryRepositoryImpl.java
@@ -158,7 +158,7 @@ public class EpisodeQueryRepositoryImpl implements EpisodeQueryRepository {
                                 episode.description,
                                 episode.viewCount,
                                 episode.episodeNumber,
-                                episode.createdAt
+                                episode.publishedAt
                         )
                 )
                 .from(episode)

--- a/novelservice/src/main/java/com/iucyh/novelservice/episode/repository/query/projection/EpisodeSummaryQueryProjection.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/episode/repository/query/projection/EpisodeSummaryQueryProjection.java
@@ -15,13 +15,13 @@ public class EpisodeSummaryQueryProjection {
     private final String description;
     private final Integer viewCount;
     private final Integer episodeNumber;
-    private final LocalDateTime createdAt;
+    private final LocalDateTime publishedAt;
 
     @QueryProjection
     public EpisodeSummaryQueryProjection(
             String publicId, EpisodeType episodeType, String title, String description,
             Integer viewCount, Integer episodeNumber,
-            LocalDateTime createdAt
+            LocalDateTime publishedAt
     ) {
         this.publicId = publicId;
         this.episodeType = episodeType;
@@ -29,6 +29,6 @@ public class EpisodeSummaryQueryProjection {
         this.description = description;
         this.viewCount = viewCount;
         this.episodeNumber = episodeNumber;
-        this.createdAt = createdAt;
+        this.publishedAt = publishedAt;
     }
 }

--- a/novelservice/src/main/java/com/iucyh/novelservice/episode/web/dto/mapper/EpisodeResponseMapper.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/episode/web/dto/mapper/EpisodeResponseMapper.java
@@ -34,7 +34,7 @@ public class EpisodeResponseMapper {
                 episode.getTitle(),
                 episode.getDescription(),
                 episode.getViewCount(),
-                episode.getCreatedAt()
+                episode.getPublishedAt()
         );
     }
 


### PR DESCRIPTION
## 🔖 연관된 이슈
- #161
## 🧾 작업 내용
- EpisodeSummaryQueryProjection 의 createdAt 필드명을 publishedAt 으로 변경하였습니다.
- EpisodeQueryRepository의 회차 목록 조회에서 createdAt 대신 publishedAt 을 조회하도록 변경하였습니다.
## 🔍 참고


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정
* 에피소드 요약에 표시되는 타임스탬프를 수정했습니다. 이제 에피소드 생성일 대신 발행일을 표시합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->