### PR TITLE
Feature: 가장 최신 회차 등록일 조회 쿼리를 발행일 조회로 변경

### DIFF
--- a/novelservice/src/main/java/com/iucyh/novelservice/episode/repository/query/EpisodeQueryRepository.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/episode/repository/query/EpisodeQueryRepository.java
@@ -20,13 +20,13 @@ public interface EpisodeQueryRepository {
     boolean episodeExistsByNovelIdAndEpisodeType(Long novelId, EpisodeType episodeType);
 
     /**
-     * <p>{@code novelId}에 해당하는 소설에 속한 회차 중 가장 최신 회차의 생성일 조회</p>
+     * <p>{@code novelId}에 해당하는 소설에 속한 회차 중 가장 최신 회차의 발행일 조회</p>
      * <p>전달된 {@code id}에 해당하는 회차와 삭제된 회차를 제외하고 나머지를 대상으로 조회</p>
      * @param novelId 조회할 회차들이 속한 소설의 id
      * @param id 추가로 제외할 회차의 pk
-     * @return 가장 최신 회차의 생성일, 결과가 없다면 {@code null}
+     * @return 가장 최신 회차의 발행일, 결과가 없다면 {@code null}
      */
-    LocalDateTime findLastEpisodeAtExceptDeletedEpisode(Long novelId, Long id);
+    LocalDateTime findLastEpisodePublishedAt(Long novelId, Long id);
 
     /**
      * <p>현재 회차의 이전 회차 조회</p>

--- a/novelservice/src/main/java/com/iucyh/novelservice/episode/repository/query/EpisodeQueryRepositoryImpl.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/episode/repository/query/EpisodeQueryRepositoryImpl.java
@@ -44,9 +44,9 @@ public class EpisodeQueryRepositoryImpl implements EpisodeQueryRepository {
     }
 
     @Override
-    public LocalDateTime findLastEpisodeAtExceptDeletedEpisode(Long novelId, Long id) {
+    public LocalDateTime findLastEpisodePublishedAt(Long novelId, Long id) {
         return queryFactory
-                .select(episode.createdAt)
+                .select(episode.publishedAt)
                 .from(episode)
                 .where(
                         episode.novel.id.eq(novelId),

--- a/novelservice/src/main/java/com/iucyh/novelservice/episode/service/EpisodeService.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/episode/service/EpisodeService.java
@@ -79,9 +79,9 @@ public class EpisodeService {
         novelPolicyValidator.validateNovelNotCompleted(novel); // 완결된 소설은 회차 삭제 불가
         episode.softDelete();
 
-        // 가장 최신 회차의 등록일을 가장 최신 회차 발행일로 변환 후 novel에 저장 (최신 회차 등록일 조회 시 삭제중인 회차, 삭제된 회차는 제외)
-        LocalDateTime lastEpisodeAt = episodeQueryRepository.findLastEpisodeAtExceptDeletedEpisode(novel.getId(), episode.getId());
-        LocalDate lastEpisodePublishDate = toLastEpisodePublishDate(lastEpisodeAt);
+        // 가장 최신 회차의 발행일시를 가장 최신 회차 발행일로 변환 후 novel에 저장 (최신 회차 발행일시 조회 시 삭제중인 회차, 삭제된 회차는 제외)
+        LocalDateTime lastEpisodePublishedAt = episodeQueryRepository.findLastEpisodePublishedAt(novel.getId(), episode.getId());
+        LocalDate lastEpisodePublishDate = toLastEpisodePublishDate(lastEpisodePublishedAt);
 
         // 소설에 더 이상 회차가 한개도 존재하지 않으면 자연스럽게 null로 설정
         novel.updateLastEpisodePublishDate(lastEpisodePublishDate);


### PR DESCRIPTION
## 🔖 연관된 이슈
- #161 
## 🧾 작업 내용
- EpisodeQueryRepository의 가장 최신 회차 등록일 조회 쿼리를 가장 최신 회차 발행일 조회로 변경하고, 메서드의 문서 주석을 갱신하였습니다.
- EpisodeService에서 해당 메서드의 반환값을 받는 변수의 이름과 관련 주석을 변경하였습니다.
## 🔍 참고

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 소설의 최신 에피소드 날짜 추적 방식을 개선했습니다. 이제 에피소드 생성 날짜 대신 발행 날짜를 기준으로 최신 에피소드 정보를 정확하게 관리합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->