### PR TITLE
Chore: 회차 상세 조회 응답 createdAt 필드명 변경

### DIFF
--- a/novelservice/src/main/java/com/iucyh/novelservice/episode/web/dto/response/EpisodeDetailResponse.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/episode/web/dto/response/EpisodeDetailResponse.java
@@ -12,7 +12,7 @@ public record EpisodeDetailResponse(
         EpisodeType episodeType,
         String title,
         String description,
-        LocalDateTime createdAt,
+        LocalDateTime publishedAt,
         NovelInfo novel,
         EpisodePrevNext prevNext
 ) {


### PR DESCRIPTION
## 🔖 연관된 이슈
- #159
## 🧾 작업 내용
- EpisodeDetailResponse 의 createdAt 필드명을 publishedAt 으로 변경하였습니다.
## 🔍 참고


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * API 응답 필드명이 변경되었습니다. 에피소드 상세 정보 조회 시 응답 필드명이 업데이트되었으므로 API 클라이언트에서 필드명을 맞춰 주시기 바랍니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->