### PR TITLE
Chore: EpisodeSummaryResponse createdAt 필드명 변경

### DIFF
--- a/novelservice/src/main/java/com/iucyh/novelservice/episode/web/dto/response/EpisodeSummaryResponse.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/episode/web/dto/response/EpisodeSummaryResponse.java
@@ -12,5 +12,5 @@ public record EpisodeSummaryResponse(
         String title,
         String description,
         int viewCount,
-        LocalDateTime createdAt
+        LocalDateTime publishedAt
 ) {}


### PR DESCRIPTION
## 🔖 연관된 이슈
- #159
## 🧾 작업 내용
- EpisodeSummaryResponse 의 createdAt 필드명을 publishedAt으로 변경하였습니다.
## 🔍 참고


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경 사항

* **버그 수정**
  * 에피소드 요약 응답의 필드명을 `createdAt`에서 `publishedAt`으로 변경했습니다. API 응답 구조가 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->