### PR TITLE
Refactoring: EpisodeService 마지막 회차 발행일 변환 메서드 인자 및 주석 변경

### DIFF
--- a/novelservice/src/main/java/com/iucyh/novelservice/episode/service/EpisodeService.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/episode/service/EpisodeService.java
@@ -46,7 +46,7 @@ public class EpisodeService {
             case COMMON -> createCommonEpisode(command, novel);
             case PROLOGUE -> createPrologueEpisode(command, novel);
         };
-        LocalDate lastEpisodePublishDate = toLastEpisodePublishDate(savedEpisode.getCreatedAt());
+        LocalDate lastEpisodePublishDate = toLastEpisodePublishDate(savedEpisode.getPublishedAt());
         novel.updateLastEpisodePublishDate(lastEpisodePublishDate);
 
         // COMMON 회차 생성 시 관련 컬럼 업데이트

--- a/novelservice/src/main/java/com/iucyh/novelservice/episode/service/EpisodeService.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/episode/service/EpisodeService.java
@@ -108,12 +108,12 @@ public class EpisodeService {
     }
 
     /**
-     * <p>전달받은 {@code LocalDateTime} 타입의 회차 등록일을 {@code LocalDate} 타입의 마지막 회차 발행일로 변환</p>
-     * @param episodeCreatedAt 변환할 회차의 등록일
-     * @return 변환된 결과, episodeCreatedAt이 null이라면 그 값 그대로 반환
+     * <p>전달받은 {@code LocalDateTime} 타입의 회차 발행일시를 {@code LocalDate} 타입의 마지막 회차 발행일로 변환</p>
+     * @param episodePublishedAt 변환할 회차의 발행일시
+     * @return 변환된 결과, episodePublishedAt이 null이라면 그 값 그대로 반환
      */
-    private LocalDate toLastEpisodePublishDate(LocalDateTime episodeCreatedAt) {
-        return episodeCreatedAt == null ? null : episodeCreatedAt.toLocalDate();
+    private LocalDate toLastEpisodePublishDate(LocalDateTime episodePublishedAt) {
+        return episodePublishedAt == null ? null : episodePublishedAt.toLocalDate();
     }
 
     private Novel findNovelWithUserId(long userId, String novelPublicId) {


### PR DESCRIPTION
## 🔖 연관된 이슈
- #160 
## 🧾 작업 내용
- EpisodeService의 회차 발행일시 -> 마지막 회차 발행일 변환 메서드에서 인자 이름을 episodePublishedAt 으로 변경하고, 관련 주석을 수정했습니다.
- EpisodeService의 회차 생성 메서드에서 마지막 회차 발행일 변환 메서드로 넘기는 인자를 publishedAt 으로 수정했습니다.
## 🔍 참고


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정
* 에피소드의 최종 발행 날짜 표시가 정확하게 개선되었습니다. 생성 날짜 대신 실제 발행 날짜를 기준으로 표시하도록 수정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->