### PR TITLE
Refactoring: 로컬 DB 스키마 컨벤션 반영

### DIFF
--- a/novelservice/docker/db/mysql/init/100-schema.sql
+++ b/novelservice/docker/db/mysql/init/100-schema.sql
@@ -1,4 +1,4 @@
-USE `novel_service`;
+USE novel_service;
 
 DROP TABLE IF EXISTS `user`;
 CREATE TABLE `user`
@@ -8,9 +8,9 @@ CREATE TABLE `user`
     email      VARCHAR(320) NOT NULL UNIQUE,
     password   VARCHAR(255) NOT NULL,
     nickname   VARCHAR(20)  NOT NULL,
-    bio        VARCHAR(100) NOT NULL DEFAULT '',
-    created_at DATETIME     NOT NULL DEFAULT NOW(),
-    updated_at DATETIME     NOT NULL DEFAULT NOW(),
+    bio        VARCHAR(100) NOT NULL,
+    created_at DATETIME     NOT NULL,
+    updated_at DATETIME     NOT NULL,
     deleted_at DATETIME NULL
 );
 
@@ -21,7 +21,7 @@ CREATE TABLE `novel`
     user_id                   BIGINT       NOT NULL,
     public_id                 VARCHAR(25)  NOT NULL UNIQUE,
     title                     VARCHAR(50)  NOT NULL,
-    description               VARCHAR(500) NOT NULL DEFAULT '',
+    description               VARCHAR(500) NOT NULL,
     category                  VARCHAR(50)  NOT NULL,
     common_episode_count      INT          NOT NULL DEFAULT 0,
     like_count                INT          NOT NULL DEFAULT 0,
@@ -29,10 +29,10 @@ CREATE TABLE `novel`
     period_view_count         INT          NOT NULL DEFAULT 0,
     max_episode_number        INT          NOT NULL DEFAULT 0,
     last_episode_publish_date DATE NULL,
-    is_completed              BOOLEAN      NOT NULL DEFAULT FALSE,
+    is_completed              BOOLEAN      NOT NULL,
     published_at              DATETIME     NOT NULL,
-    created_at                DATETIME     NOT NULL DEFAULT NOW(),
-    updated_at                DATETIME     NOT NULL DEFAULT NOW(),
+    created_at                DATETIME     NOT NULL,
+    updated_at                DATETIME     NOT NULL,
     deleted_at                DATETIME NULL,
 
     CONSTRAINT fk_novel_user FOREIGN KEY (user_id) REFERENCES user (user_id),
@@ -47,13 +47,13 @@ CREATE TABLE `episode`
     public_id      VARCHAR(25) NOT NULL UNIQUE,
     episode_type   VARCHAR(50) NOT NULL,
     title          VARCHAR(50) NOT NULL,
-    description    VARCHAR(35) NOT NULL DEFAULT '',
+    description    VARCHAR(35) NOT NULL,
     content        TEXT        NOT NULL,
     episode_number INT         NOT NULL,
     view_count     INT         NOT NULL DEFAULT 0,
     published_at   DATETIME    NOT NULL,
-    created_at     DATETIME    NOT NULL DEFAULT NOW(),
-    updated_at     DATETIME    NOT NULL DEFAULT NOW(),
+    created_at     DATETIME    NOT NULL,
+    updated_at     DATETIME    NOT NULL,
     deleted_at     DATETIME NULL,
 
     CONSTRAINT fk_episode_novel FOREIGN KEY (novel_id) REFERENCES novel (novel_id),
@@ -66,7 +66,7 @@ CREATE TABLE `novel_like`
     novel_like_id BIGINT AUTO_INCREMENT PRIMARY KEY,
     user_id       BIGINT   NOT NULL,
     novel_id      BIGINT   NOT NULL,
-    created_at    DATETIME NOT NULL DEFAULT NOW(),
+    created_at    DATETIME NOT NULL,
 
     CONSTRAINT fk_novel_like_user FOREIGN KEY (user_id) REFERENCES user (user_id),
     CONSTRAINT fk_novel_like_novel FOREIGN KEY (novel_id) REFERENCES novel (novel_id),
@@ -94,7 +94,7 @@ CREATE TABLE `novel_period_stats`
     start_date           DATE        NOT NULL,
     end_date             DATE        NOT NULL,
     view_count           INT         NOT NULL DEFAULT 0,
-    updated_at           DATETIME    NOT NULL DEFAULT NOW(),
+    updated_at           DATETIME    NOT NULL,
 
     CONSTRAINT fk_novel_period_stat_novel FOREIGN KEY (novel_id) REFERENCES novel (novel_id),
     UNIQUE KEY uq_novel_start_end (novel_id, period_type, start_date, end_date)

--- a/novelservice/docker/db/mysql/init/100-schema.sql
+++ b/novelservice/docker/db/mysql/init/100-schema.sql
@@ -4,14 +4,17 @@ DROP TABLE IF EXISTS `user`;
 CREATE TABLE `user`
 (
     user_id    BIGINT AUTO_INCREMENT PRIMARY KEY,
-    public_id  VARCHAR(25)  NOT NULL UNIQUE,
-    email      VARCHAR(320) NOT NULL UNIQUE,
+    public_id  VARCHAR(25)  NOT NULL,
+    email      VARCHAR(320) NOT NULL,
     password   VARCHAR(255) NOT NULL,
     nickname   VARCHAR(20)  NOT NULL,
     bio        VARCHAR(100) NOT NULL,
     created_at DATETIME     NOT NULL,
     updated_at DATETIME     NOT NULL,
-    deleted_at DATETIME NULL
+    deleted_at DATETIME NULL,
+
+    UNIQUE KEY uq_user_public_id (public_id),
+    UNIQUE KEY uq_user_email (email)
 );
 
 DROP TABLE IF EXISTS `novel`;
@@ -19,7 +22,7 @@ CREATE TABLE `novel`
 (
     novel_id                  BIGINT AUTO_INCREMENT PRIMARY KEY,
     user_id                   BIGINT       NOT NULL,
-    public_id                 VARCHAR(25)  NOT NULL UNIQUE,
+    public_id                 VARCHAR(25)  NOT NULL,
     title                     VARCHAR(50)  NOT NULL,
     description               VARCHAR(500) NOT NULL,
     category                  VARCHAR(50)  NOT NULL,
@@ -36,7 +39,8 @@ CREATE TABLE `novel`
     deleted_at                DATETIME NULL,
 
     CONSTRAINT fk_novel_user FOREIGN KEY (user_id) REFERENCES user (user_id),
-    UNIQUE KEY uq_user_title (user_id, title)
+    UNIQUE KEY uq_novel_public_id (public_id),
+    UNIQUE KEY uq_novel_user_id_title (user_id, title)
 );
 
 DROP TABLE IF EXISTS `episode`;
@@ -44,7 +48,7 @@ CREATE TABLE `episode`
 (
     episode_id     BIGINT AUTO_INCREMENT PRIMARY KEY,
     novel_id       BIGINT      NOT NULL,
-    public_id      VARCHAR(25) NOT NULL UNIQUE,
+    public_id      VARCHAR(25) NOT NULL,
     episode_type   VARCHAR(50) NOT NULL,
     title          VARCHAR(50) NOT NULL,
     description    VARCHAR(35) NOT NULL,
@@ -57,7 +61,8 @@ CREATE TABLE `episode`
     deleted_at     DATETIME NULL,
 
     CONSTRAINT fk_episode_novel FOREIGN KEY (novel_id) REFERENCES novel (novel_id),
-    UNIQUE KEY uq_novel_episode_number (novel_id, episode_number)
+    UNIQUE KEY uq_episode_public_id (public_id),
+    UNIQUE KEY uq_episode_novel_id_episode_number (novel_id, episode_number)
 );
 
 DROP TABLE IF EXISTS `novel_like`;
@@ -70,7 +75,7 @@ CREATE TABLE `novel_like`
 
     CONSTRAINT fk_novel_like_user FOREIGN KEY (user_id) REFERENCES user (user_id),
     CONSTRAINT fk_novel_like_novel FOREIGN KEY (novel_id) REFERENCES novel (novel_id),
-    UNIQUE KEY uq_user_novel (user_id, novel_id)
+    UNIQUE KEY uq_novel_like_user_id_novel_id (user_id, novel_id)
 );
 
 DROP TABLE IF EXISTS `novel_daily_stats`;
@@ -81,8 +86,8 @@ CREATE TABLE `novel_daily_stats`
     stat_date           DATE   NOT NULL,
     view_count          INT    NOT NULL DEFAULT 0,
 
-    CONSTRAINT fk_novel_daily_stat_novel FOREIGN KEY (novel_id) REFERENCES novel (novel_id),
-    UNIQUE KEY uq_novel_stat_date (novel_id, stat_date)
+    CONSTRAINT fk_novel_daily_stats_novel FOREIGN KEY (novel_id) REFERENCES novel (novel_id),
+    UNIQUE KEY uq_novel_daily_stats_novel_id_stat_date (novel_id, stat_date)
 );
 
 DROP TABLE IF EXISTS `novel_period_stats`;
@@ -96,6 +101,6 @@ CREATE TABLE `novel_period_stats`
     view_count           INT         NOT NULL DEFAULT 0,
     updated_at           DATETIME    NOT NULL,
 
-    CONSTRAINT fk_novel_period_stat_novel FOREIGN KEY (novel_id) REFERENCES novel (novel_id),
-    UNIQUE KEY uq_novel_start_end (novel_id, period_type, start_date, end_date)
+    CONSTRAINT fk_novel_period_stats_novel FOREIGN KEY (novel_id) REFERENCES novel (novel_id),
+    UNIQUE KEY uq_novel_period_stats_novel_id_period_type_start_date_end_date (novel_id, period_type, start_date, end_date)
 );


### PR DESCRIPTION
## 🔖 연관된 이슈
- #170
## 🧾 작업 내용
- 로컬 DB 스키마 스크립트를 새로 정의된 컨벤션에 맞게 수정했습니다.
## 🔍 참고
- 더미 데이터들은 다음 PR에서 수정할 예정입니다.
---
### 관련 컨벤션
### UNIQUE 키
| 분류 | 규칙 | 비고 | 예시 |
| --- | --- | --- | --- |
| 기본 | - uq_{테이블명}_{컬럼명…} | 컬럼명의 순서는 실제 UNIQUE 키의 컬럼 순서와 일치 | novel의 (user_id, title) 에 대한 복합 UNIQUE 키: uq_novel_user_id_title |
### 기본값

| 분류 | 관리 주체 (DB or APP) | 기본값 | 비고 |
| --- | --- | --- | --- |
| 조회수, 좋아요수 등 정수형 집계(파생) 컬럼, 역대 최대 회차 번호(max_episode_number) 등 시퀀스 성격의 컬럼 | DB & APP | 일반적으로 0 (컬럼의 성격에 따라 달라질 수 있음) | DB 레벨에서는 직접 SQL을 통해 DB를 조작하는 등의 상황에서 안정성과 편의성을 높이고, 값의 명확성을 위해 기본값을 추가 <br> 애플리케이션 레벨에서는 엔티티 저장 직후 필드 값들을 활용해야 하는 등의 상황에서 편의성을 높이고, 명확성도 높이기 위해 기본값을 DB와 동일하게 명시 |
| 문자열 | APP | ‘’ (빈 문자열) | 특수한 요구사항이 있는 것이 아니라면 문자열이 비어있다는 것은 빈 문자열로 표현 <br> DB에서는 해당 컬럼을 NOT NULL 로 설정하여 NULL 이 들어오지 못하도록 원천 차단 <br> 해당 기본값은 백엔드 애플리케이션에서 명시적으로 설정할수도 있으나 설정하지 않고 엔티티 생성 시 API 요청에서 필수적으로 값을 받도록 하는 방식을 권장 |
| 생성일, 수정일 | APP | 현재 시간 | 엔티티 생성 직후 해당 필드 값들을 활용해야 할수도 있고, 시간 관련 컬럼들은 DB와 APP 중 한 곳에서만 관리하는 것이 일관성을 높이고 타임존 문제도 최소화 할 수 있으므로 애플리케이션 레벨에서만 관리 |
| 삭제일 | APP | NULL | 삭제 시 애플리케이션에서 삭제일 필드에 직접 현재 시간을 설정 |
| 발행일, 완결 여부 등 비즈니스적인 의미가 있는 컬럼 | APP | - (각 컬럼의 비즈니스 규칙에 따라 상이) | 비즈니스적인 의미가 있는 컬럼들은 상황에 따라 넣는 기본값이 달라질수도 있으므로 유연성을 위해 애플리케이션 레벨에서 관리 |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **작업**
  * 데이터베이스 스키마가 개선되었습니다. 테이블 제약 조건이 더욱 명확하게 구조화되었으며, 데이터 검증 규칙이 강화되어 전반적인 데이터 무결성과 일관성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->