### PR TITLE
Refactoring: 로컬 DB 인덱스 설정 스크립트 컨벤션 반영

### DIFF
--- a/novelservice/docker/db/mysql/init/200-index.sql
+++ b/novelservice/docker/db/mysql/init/200-index.sql
@@ -1,10 +1,10 @@
 USE `novel_service`;
 
 -- ==== novel ====
-CREATE INDEX idx_popular ON novel (deleted_at, period_view_count DESC, last_episode_publish_date DESC, novel_id DESC);
-CREATE INDEX idx_last_update ON novel (deleted_at, last_episode_publish_date DESC, total_view_count DESC, novel_id DESC);
-CREATE INDEX idx_view_count ON novel (deleted_at, total_view_count DESC, last_episode_publish_date DESC, novel_id DESC);
-CREATE INDEX idx_like_count ON novel (deleted_at, like_count DESC, total_view_count DESC, novel_id DESC);
+CREATE INDEX idx_novel_sort_popular ON novel (deleted_at, period_view_count DESC, last_episode_publish_date DESC, novel_id DESC);
+CREATE INDEX idx_novel_sort_last_update ON novel (deleted_at, last_episode_publish_date DESC, total_view_count DESC, novel_id DESC);
+CREATE INDEX idx_novel_sort_view_count ON novel (deleted_at, total_view_count DESC, last_episode_publish_date DESC, novel_id DESC);
+CREATE INDEX idx_novel_sort_like_count ON novel (deleted_at, like_count DESC, total_view_count DESC, novel_id DESC);
 
 -- with category (일단 기본값으로 쓰이는 인기순에 대해서만 생성)
-CREATE INDEX idx_popular_category ON novel (deleted_at, category, period_view_count DESC, last_episode_publish_date DESC, novel_id DESC);
+CREATE INDEX idx_novel_sort_popular_category ON novel (deleted_at, category, period_view_count DESC, last_episode_publish_date DESC, novel_id DESC);


### PR DESCRIPTION
## 🔖 연관된 이슈
- #171
## 🧾 작업 내용
- 로컬 DB 인덱스 설정 스크립트의 인덱스명들을 새로 정의한 컨벤션에 맞게 수정했습니다.
## 🔍 참고
### 관련 컨벤션
### 인덱스
| 분류 | 규칙 | 비고 | 예시 |
| --- | --- | --- | --- |
| 기본 | - idx\_{테이블명}\_{컬럼명…} | 컬럼명의 순서는 실제 인덱스의 컬럼 순서와 일치 | novel의 (user_id, title) 에 대한 복합 인덱스: idx\_novel\_user\_id\_title |
| 목록 조회의 정렬 기준 | - idx\_{테이블명}\_sort\_{정렬 기준명}\_{추가 필터 컬럼명…} | 추가 필터는 필요하면 명시, 추가 필터가 없다면 명시하지 않음 | 인기순: idx\_novel\_sort\_popular <br> 인기순 + 카테고리 필터: idx\_novel\_sort\_popular\_category |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **Chores**
  * 데이터베이스 인덱스 네이밍 규칙을 개선했습니다. 인덱스 이름이 업데이트되었으나 기능적 변화는 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->