### PR TITLE
Refactoring: NovelQueryService novel 목록 조회 공통 내부 메서드 개선

### DIFF
--- a/novelservice/src/main/java/com/iucyh/novelservice/novel/repository/custom/paging/NovelPagingStrategy.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/novel/repository/custom/paging/NovelPagingStrategy.java
@@ -6,7 +6,7 @@ import com.iucyh.novelservice.novel.repository.custom.paging.cursor.NovelCursor;
 import com.querydsl.jpa.impl.JPAQuery;
 
 /**
- * <p>Novel의 각 정렬 기준에 맞는 페이징 쿼리 생성을 위한 전략</p>
+ * <p>Novel의 각 정렬 기준에 맞는 페이징 전/후처리 전략</p>
  */
 public interface NovelPagingStrategy {
 

--- a/novelservice/src/main/java/com/iucyh/novelservice/novel/service/NovelQueryService.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/novel/service/NovelQueryService.java
@@ -81,19 +81,11 @@ public class NovelQueryService {
             return NovelResponseMapper.toPageResponse(List.of(), null, limit);
         }
 
-        List<Novel> pageResult = result.stream().limit(limit).toList();
-
+        List<Novel> limitedResult = result.stream().limit(limit).toList(); // 클라이언트로 응답할 최종 결과 (limit만큼 자르기)
         PageSizeInfo pageSizeInfo = new PageSizeInfo(result.size(), limit);
-        String newCursor = createNewCursor(pagingStrategy, pageResult, pageSizeInfo);
+        String newCursor = createNewCursor(pagingStrategy, limitedResult, pageSizeInfo);
 
-        List<NovelSummaryResponse> novels = mapToNovelResponseList(pageResult);
-        return NovelResponseMapper.toPageResponse(novels, newCursor, limit);
-    }
-
-    private List<NovelSummaryResponse> mapToNovelResponseList(List<Novel> novels) {
-        return novels.stream()
-                .map(NovelResponseMapper::toNovelSummaryResponse)
-                .toList();
+        return NovelResponseMapper.toPageResponse(limitedResult, newCursor, limit);
     }
 
     /**

--- a/novelservice/src/main/java/com/iucyh/novelservice/novel/service/NovelQueryService.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/novel/service/NovelQueryService.java
@@ -58,7 +58,7 @@ public class NovelQueryService {
      * <p>Novel Page 조회를 위한 공통 메서드</p>
      * @param finder 각 조회 종류별로 필요한 메서드 호출 로직을 담는 람다식
      *               <br>
-     *               e.g) 조회 종류별 리포지토리 메서드 호출, 특정 비즈니스 로직을 위한 메서드 호출 및 조건 검사 등
+     *               e.g) 조회 종류별 리포지토리 조회 메서드 호출 등
      * @return 최종 결과를 담은 {@code PageWithCursorResponse<NovelSummaryResponse>}
      */
     private PageWithCursorResponse<NovelSummaryResponse> findNovels(
@@ -66,11 +66,10 @@ public class NovelQueryService {
             BiFunction<NovelPagingCondition, NovelPagingStrategy, List<Novel>> finder
     ) {
         NovelPagingStrategy pagingStrategy = pagingStrategyRegistry.get(sortType);
-        NovelCursor decodedCursor = null;
+        NovelCursor decodedCursor = decodeCursor(cursor, pagingStrategy.getCursorClass());
 
-        if (cursor != null && !cursor.isBlank()) {
-            decodedCursor = cursorCodec.decode(cursor, pagingStrategy.getCursorClass());
-            // JSON은 필드 순서를 신경쓰지 않기 때문에 필드명만 같다면 서로 다른 정렬 기준끼리도 커서가 호환될 수 있으므로 별도로 추가 검증
+        // JSON은 필드 순서를 신경쓰지 않기 때문에 필드명만 같다면 서로 다른 정렬 기준끼리도 커서가 호환될 수 있으므로 별도로 추가 검증
+        if (decodedCursor != null) {
             novelPolicyValidator.validateNovelCursorMatchesSortType(decodedCursor, sortType);
         }
 
@@ -83,12 +82,9 @@ public class NovelQueryService {
         }
 
         List<Novel> pageResult = result.stream().limit(limit).toList();
-        String newCursor = null;
 
-        boolean hasNext = result.size() > limit;
-        if (hasNext) { // 다음에 가져올 데이터가 존재할 때(다음 페이지가 존재할 때)만 새 cursor 생성
-            newCursor = createNewEncodedCursor(pagingStrategy, pageResult);
-        }
+        PageSizeInfo pageSizeInfo = new PageSizeInfo(result.size(), limit);
+        String newCursor = createNewCursor(pagingStrategy, pageResult, pageSizeInfo);
 
         List<NovelSummaryResponse> novels = mapToNovelResponseList(pageResult);
         return NovelResponseMapper.toPageResponse(novels, newCursor, limit);
@@ -100,9 +96,46 @@ public class NovelQueryService {
                 .toList();
     }
 
-    private String createNewEncodedCursor(NovelPagingStrategy pagingStrategy, List<Novel> novels) {
-        Novel lastResult = novels.get(novels.size() - 1);
+    /**
+     * <p>클라이언트로부터 받은 {@code String} 타입의 커서를 {@code NovelCursor} 타입의 객체로 디코딩</p>
+     * @param cursor 클라이언트로부터 받은 원본 커서
+     * @param cursorClass 디코딩 될 {@code NovelCursor} 클래스 (앞서 선택된 전략의 getCursorClass() 메서드 사용 권장)
+     * @return {@code cursor}가 {@code null}이거나 비어있다면(blank) {@code null}, 아니라면 디코딩 된 {@code NovelCursor} 객체
+     */
+    private NovelCursor decodeCursor(String cursor, Class<? extends NovelCursor> cursorClass) {
+        if (cursor == null || cursor.isBlank()) {
+            return null;
+        }
+
+        return cursorCodec.decode(cursor, cursorClass);
+    }
+
+    /**
+     * <p>현재 페이지 결과에 대한 인코딩 된 새 커서 생성</p>
+     * @param pagingStrategy 조회 시 사용한 전략
+     * @param pageResult 원본이 아닌 외부(클라이언트)로 내보낼 가공이 끝난 최종 결과 리스트
+     * @param sizeInfo 페이지 결과의 크기 관련 정보 (자세한 내용은 {@code PageSizeInfo} 문서 주석 참고, 필독 요망)
+     * @return 커서 생성 조건에 부합하지 않다면 {@code null}, 부합하다면 인코딩된 {@code String} 타입의 새 커서
+     */
+    private String createNewCursor(NovelPagingStrategy pagingStrategy, List<Novel> pageResult, PageSizeInfo sizeInfo) {
+        if (!sizeInfo.hasNextPage()) {
+            return null;
+        }
+
+        Novel lastResult = pageResult.get(pageResult.size() - 1);
         NovelCursor newCursor = pagingStrategy.createCursor(lastResult);
         return cursorCodec.encode(newCursor);
+    }
+
+    /**
+     * <p>Novel 페이지 결과의 크기 관련 정보를 캡슐화한 내부 레코드</p>
+     * @param originalSize 원본(데이터 조회 시 리포지토리로부터 받은 전혀 가공되지 않은 결과)의 크기 (List.size())
+     * @param limit 클라이언트로부터 전달받은 limit (역시 임의로 증감시키거나 감소시키지 않은 원래 값)
+     */
+    private record PageSizeInfo(int originalSize, int limit) {
+
+        public boolean hasNextPage() {
+            return originalSize > limit;
+        }
     }
 }

--- a/novelservice/src/main/java/com/iucyh/novelservice/novel/web/dto/mapper/NovelResponseMapper.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/novel/web/dto/mapper/NovelResponseMapper.java
@@ -69,7 +69,10 @@ public class NovelResponseMapper {
         return new NovelLikeCountResponse(likeCount);
     }
 
-    public static PageWithCursorResponse<NovelSummaryResponse> toPageResponse(List<NovelSummaryResponse> novels, String encodedCursor, int size) {
-        return new PageWithCursorResponse<>(size, encodedCursor, novels);
+    public static PageWithCursorResponse<NovelSummaryResponse> toPageResponse(List<Novel> novels, String encodedCursor, int limit) {
+        List<NovelSummaryResponse> result = novels.stream()
+                .map(NovelResponseMapper::toNovelSummaryResponse)
+                .toList();
+        return new PageWithCursorResponse<>(limit, encodedCursor, result);
     }
 }


### PR DESCRIPTION
## 🔖 연관된 이슈
- #184
## 🧾 작업 내용
- novel 목록 조회 메서드의 코드 가독성을 개선하고, 일부 로직을 메서드로 묶어 유지보수성을 높였습니다.
- novel 페이지 응답 매핑 로직에서 List<NovelSummaryResponse>가 아닌 List<Novel> 타입을 직접 받도록 해 다른 mapper 메서드들과의 일관성을 높이고 사용처의 편의성을 높였습니다.
## 🔍 참고


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Documentation**
  * 페이징 전략 관련 문서 설명 업데이트

* **Refactor**
  * 커서 처리 및 페이지네이션 로직 내부 최적화
  * 페이지 응답 매핑 프로세스 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->