### PR TITLE
Feature: Novel 낙관적 락 적용

### DIFF
--- a/novelservice/docker/mysql/init/100-schema.sql
+++ b/novelservice/docker/mysql/init/100-schema.sql
@@ -23,6 +23,7 @@ CREATE TABLE `novel`
     novel_id                  BIGINT AUTO_INCREMENT PRIMARY KEY,
     user_id                   BIGINT       NOT NULL,
     public_id                 VARCHAR(25)  NOT NULL,
+    version                   BIGINT       NOT NULL DEFAULT 0,
     title                     VARCHAR(50)  NOT NULL,
     description               VARCHAR(500) NOT NULL,
     category                  VARCHAR(50)  NOT NULL,

--- a/novelservice/src/main/java/com/iucyh/novelservice/episode/service/EpisodeService.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/episode/service/EpisodeService.java
@@ -50,7 +50,7 @@ public class EpisodeService {
         // COMMON 회차 생성 시 관련 컬럼 업데이트
         if (command.episodeType() == EpisodeType.COMMON) {
             novel.updateMaxEpisodeNumber(savedEpisode.getEpisodeNumber());
-            novelRepository.increaseCommonEpisodeCount(novel.getId());
+            novel.increaseCommonEpisodeCount();
         }
 
         return EpisodeResponseMapper.toEpisodeSaveResponse(savedEpisode);
@@ -70,6 +70,7 @@ public class EpisodeService {
         episode.updateContent(command.content().getSanitizedValue());
     }
 
+    // TODO: 락 예외 발생 시 재시도 기능 구현
     public void deleteEpisode(DeleteEpisodeCommand command) {
         Episode episode = findEpisodeWithNovelUserFetch(command.episodePublicId(), command.userId());
         Novel novel = episode.getNovel();
@@ -86,13 +87,12 @@ public class EpisodeService {
 
         // COMMON 회차와 관련된 컬럼 업데이트 (삭제하려는 회차가 COMMON이 아니라면 COMMON과 관련된 상태는 변하지 않으므로 업데이트 스킵)
         if (episode.getEpisodeType() == EpisodeType.COMMON) {
-            // DB 레벨에서 음수값 방지
-            novelRepository.decreaseCommonEpisodeCount(novel.getId());
+            novel.decreaseCommonEpisodeCount();
         }
     }
 
     private Episode createCommonEpisode(CreateEpisodeCommand command, Novel novel) {
-        int newEpisodeNumber = novel.getMaxEpisodeNumber() + 1;
+        int newEpisodeNumber = novel.getNextEpisodeNumber();
 
         Episode episode = EpisodeCommandMapper.toEpisode(command, novel, newEpisodeNumber, LocalDateTime.now());
         return episodeRepository.save(episode);

--- a/novelservice/src/main/java/com/iucyh/novelservice/episode/service/EpisodeService.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/episode/service/EpisodeService.java
@@ -92,7 +92,7 @@ public class EpisodeService {
     }
 
     private Episode createCommonEpisode(CreateEpisodeCommand command, Novel novel) {
-        int newEpisodeNumber = novel.getNextEpisodeNumber();
+        int newEpisodeNumber = novel.generateNewEpisodeNumber();
 
         Episode episode = EpisodeCommandMapper.toEpisode(command, novel, newEpisodeNumber, LocalDateTime.now());
         return episodeRepository.save(episode);

--- a/novelservice/src/main/java/com/iucyh/novelservice/novel/domain/Novel.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/novel/domain/Novel.java
@@ -25,6 +25,9 @@ public class Novel extends PublicEntity {
     @Column(name = "novel_id")
     private Long id;
 
+    @Version
+    private Long version;
+
     @Column(length = NOVEL_TITLE_LENGTH_MAX, nullable = false)
     private String title;
 
@@ -76,6 +79,10 @@ public class Novel extends PublicEntity {
         return isCompleted;
     }
 
+    public int getNextEpisodeNumber() {
+        return maxEpisodeNumber + 1;
+    }
+
     public void updateTextMetaData(String title, String description) {
         if (title != null) {
             this.title = title.strip();
@@ -107,5 +114,15 @@ public class Novel extends PublicEntity {
 
     public void updateLastEpisodePublishDate(LocalDate lastEpisodePublishDate) {
         this.lastEpisodePublishDate = lastEpisodePublishDate;
+    }
+
+    public void increaseCommonEpisodeCount() {
+        this.commonEpisodeCount++;
+    }
+
+    public void decreaseCommonEpisodeCount() {
+        if (this.commonEpisodeCount > 0) {
+            this.commonEpisodeCount--;
+        }
     }
 }

--- a/novelservice/src/main/java/com/iucyh/novelservice/novel/domain/Novel.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/novel/domain/Novel.java
@@ -79,7 +79,7 @@ public class Novel extends PublicEntity {
         return isCompleted;
     }
 
-    public int getNextEpisodeNumber() {
+    public int generateNewEpisodeNumber() {
         return maxEpisodeNumber + 1;
     }
 

--- a/novelservice/src/main/java/com/iucyh/novelservice/novel/domain/Novel.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/novel/domain/Novel.java
@@ -83,6 +83,16 @@ public class Novel extends PublicEntity {
         return maxEpisodeNumber + 1;
     }
 
+    public void increaseCommonEpisodeCount() {
+        commonEpisodeCount++;
+    }
+
+    public void decreaseCommonEpisodeCount() {
+        if (commonEpisodeCount > 0) {
+            commonEpisodeCount--;
+        }
+    }
+
     public void updateTextMetaData(String title, String description) {
         if (title != null) {
             this.title = title.strip();
@@ -114,15 +124,5 @@ public class Novel extends PublicEntity {
 
     public void updateLastEpisodePublishDate(LocalDate lastEpisodePublishDate) {
         this.lastEpisodePublishDate = lastEpisodePublishDate;
-    }
-
-    public void increaseCommonEpisodeCount() {
-        this.commonEpisodeCount++;
-    }
-
-    public void decreaseCommonEpisodeCount() {
-        if (this.commonEpisodeCount > 0) {
-            this.commonEpisodeCount--;
-        }
     }
 }

--- a/novelservice/src/main/java/com/iucyh/novelservice/novel/repository/NovelRepository.java
+++ b/novelservice/src/main/java/com/iucyh/novelservice/novel/repository/NovelRepository.java
@@ -35,30 +35,6 @@ public interface NovelRepository extends JpaRepository<Novel, Long>, NovelCustom
     """)
     Optional<Novel> findByPublicIdFetch(@Param("publicId") String publicId);
 
-    /**
-     * <p>{@code id}에 해당하는 소설의 common_episode_count 값을 1만큼 증가</p>
-     * @param id 증가시킬 소설의 pk
-     */
-    @Modifying(clearAutomatically = true)
-    @Query("""
-    update Novel n
-    set n.commonEpisodeCount = n.commonEpisodeCount + 1
-    where n.id = :id and n.deletedAt is null
-    """)
-    void increaseCommonEpisodeCount(@Param("id") Long id);
-
-    /**
-     * <p>{@code id}에 해당하는 소설의 common_episode_count 값을 1만큼 감소</p>
-     * @param id 감소시킬 소설의 pk
-     */
-    @Modifying(clearAutomatically = true)
-    @Query("""
-    update Novel n
-    set n.commonEpisodeCount = n.commonEpisodeCount - 1
-    where n.id = :id and n.commonEpisodeCount > 0 and n.deletedAt is null
-    """)
-    void decreaseCommonEpisodeCount(@Param("id") Long id);
-
     @Modifying(clearAutomatically = true)
     @Query("update Novel n set n.totalViewCount = n.totalViewCount + 1 where n.id = :novelId and n.deletedAt is null")
     void increaseTotalViewCount(@Param("novelId") Long novelId);


### PR DESCRIPTION
## 🔖 연관된 이슈
- #186 
## 🧾 작업 내용
- Novel 엔티티 및 테이블에 version 컬럼을 추가하였습니다.
- 관련 수정 로직 중 일부를 수정했습니다. 
## 🔍 참고
- novel은 소유한 작가 한 명만 관리 가능하므로 동시성 문제가 거의 터지지 않지만 그래도 터질만한 부분은 있어 낙관적 락을 적용했습니다.
- common_episode_count 같은 경우 회차 생성/삭제/복구 이벤트에서만 갱신되며 각 작업들과 밀접하게 연관이 있기 때문에 별도로 배치로 빼거나 할 가능성은 없다고 보아 기존 원자적 업데이트가 아닌 변경감지를 사용해 다른 업데이트 로직과 일관성을 높였습니다. 이를 통해 jpql로 인해 발생 가능한 버그를 예방하고, jpql 단독으로 나가는 쿼리를 없애 novel 상태 관련 업데이트 쿼리는 하나만 나가도록 하였습니다. (낙관적 락 덕분에 lost update 문제는 방지 가능하다고 보았습니다.)
- 재시도 관련 로직은 추후에 구현할 예정입니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **리팩토링**
  * 데이터 동시성 관리 메커니즘을 강화하여 데이터 일관성 개선
  * 에피소드 관리 로직을 최적화하여 시스템 안정성 향상

<!-- end of auto-generated comment: release notes by coderabbit.ai -->